### PR TITLE
[BC break] Pass events as an option instead of a required argument.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,14 +21,15 @@ export default class KintoApi {
    * Constructor.
    *
    * Options:
-   * - {Object} headers      The key-value headers to pass to each request.
-   * - {String} requestMode  The HTTP request mode.
+   * - {EventEmitter} events      The events handler. If none provided an
+   *                              `EventEmitter` instance will be created.
+   * - {Object}       headers     The key-value headers to pass to each request.
+   * - {String}       requestMode The HTTP request mode (from ES6 fetch spec).
    *
-   * @param  {String}       remote  The remote URL.
-   * @param  {EventEmitter} events  The events handler
-   * @param  {Object}       options The options object.
+   * @param  {String} remote  The remote URL.
+   * @param  {Object} options The options object.
    */
-  constructor(remote, events, options={}) {
+  constructor(remote, options={}) {
     if (typeof(remote) !== "string" || !remote.length) {
       throw new Error("Invalid remote URL: " + remote);
     }
@@ -50,10 +51,11 @@ export default class KintoApi {
      */
     this.serverSettings = null;
     /**
-     * The even emitter instance.
+     * The event emitter instance. Should comply with the `EventEmitter`
+     * interface.
      * @type {EventEmitter}
      */
-    this.events = events || new EventEmitter();
+    this.events = options.events || new EventEmitter();
 
     /**
      * The HTTP instance.

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -22,7 +22,7 @@ describe("Api", () => {
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     events = new EventEmitter();
-    api = new Api(FAKE_SERVER_URL, events);
+    api = new Api(FAKE_SERVER_URL, {events});
   });
 
   afterEach(() => {
@@ -32,46 +32,46 @@ describe("Api", () => {
   /** @test {Api#constructor} */
   describe("#constructor", () => {
     it("should check that `remote` is a string", () => {
-      expect(() => new Api(42, events))
+      expect(() => new Api(42, {events}))
         .to.Throw(Error, /Invalid remote URL/);
     });
 
     it("should validate `remote` arg value", () => {
-      expect(() => new Api("http://nope", events))
+      expect(() => new Api("http://nope"))
         .to.Throw(Error, /The remote URL must contain the version/);
     });
 
     it("should strip any trailing slash", () => {
-      expect(new Api(`http://test/${SPV}/`, events).remote).eql(`http://test/${SPV}`);
+      expect(new Api(`http://test/${SPV}/`).remote).eql(`http://test/${SPV}`);
     });
 
     it("should expose a passed events instance option", () => {
-      expect(new Api(`http://test/${SPV}`, events).events).to.eql(events);
+      expect(new Api(`http://test/${SPV}`, {events}).events).to.eql(events);
     });
 
     it("should propagate its events property to child dependencies", () => {
-      const api = new Api(`http://test/${SPV}`, events);
+      const api = new Api(`http://test/${SPV}`, {events});
       expect(api.http.events).eql(api.events);
     });
 
     it("should assign version value", () => {
-      expect(new Api(`http://test/${SPV}`, events).version).eql(SPV);
-      expect(new Api(`http://test/${SPV}/`, events).version).eql(SPV);
+      expect(new Api(`http://test/${SPV}`).version).eql(SPV);
+      expect(new Api(`http://test/${SPV}/`).version).eql(SPV);
     });
 
     it("should accept a headers option", () => {
-      expect(new Api(`http://test/${SPV}`, events, {headers: {Foo: "Bar"}}).optionHeaders)
+      expect(new Api(`http://test/${SPV}`, {headers: {Foo: "Bar"}}).optionHeaders)
         .eql({Foo: "Bar"});
     });
 
     it("should validate protocol version", () => {
-      expect(() => new Api(`http://test/v999`, events))
+      expect(() => new Api(`http://test/v999`))
         .to.Throw(Error, /^Unsupported protocol version/);
     });
 
     it("should propagate the requestMode option to the child HTTP instance", () => {
       const requestMode = "no-cors";
-      expect(new Api(`http://test/${SPV}`, events, {requestMode}).http.requestMode)
+      expect(new Api(`http://test/${SPV}`, {requestMode}).http.requestMode)
         .eql(requestMode);
     });
 
@@ -80,9 +80,9 @@ describe("Api", () => {
         .to.be.an.instanceOf(EventEmitter);
     });
 
-    it("should expose provided event emitter when provided", () => {
+    it("should expose provided event emitter as a property", () => {
       const events = new EventEmitter();
-      expect(new Api(`http://test/${SPV}`, events).events).eql(events);
+      expect(new Api(`http://test/${SPV}`, {events}).events).eql(events);
     });
   });
 


### PR DESCRIPTION
Atm if you want to have a local EventEmitter instance created for you and provide custom options, you need to write something like this:

```js
const api = new Api("http://foo", undefined, {requestMode: "cors"})
```

There's no point at providing an undefined second arg, so we should just do:

```js
const api = new Api("http://foo", {requestMode: "cors"})
```

And if we want to provide a custom event emitter:


```js
const events = new EventEmitter();
const api = new Api("http://foo", {events, requestMode: "cors"})
```

r=? @leplatrem