### PR TITLE
Initial integration test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dist-prod": "browserify -s KintoApi -g uglifyify -e src/index.js -o dist/kinto-client.min.js -t [ babelify --sourceMapRelative . ]",
     "report-coverage": "npm run test-cover && ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info",
     "tdd": "babel-node node_modules/.bin/_mocha --watch 'test/**/*_test.js'",
-    "test": "npm run lint && npm run test-nocover",
+    "test": "npm run test-nocover",
     "test-cover": "babel-node node_modules/.bin/babel-istanbul cover --report text $npm_package_config_ISTANBUL_OPTS node_modules/.bin/_mocha -- 'test/**/*_test.js'",
     "test-cover-html": "babel-node node_modules/.bin/babel-istanbul cover --report html $npm_package_config_ISTANBUL_OPTS node_modules/.bin/_mocha -- 'test/**/*_test.js' && open coverage/index.html",
     "test-nocover": "babel-node node_modules/.bin/_mocha 'test/**/*_test.js'",
@@ -48,6 +48,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
+    "btoa": "^1.1.2",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.0.0",
     "coveralls": "^2.11.6",
@@ -57,6 +58,7 @@
     "eslint": "^1.2.0",
     "mocha": "^2.3.4",
     "sinon": "^1.17.2",
-    "uglifyify": "^3.0.1"
+    "uglifyify": "^3.0.1",
+    "uuid": "^2.0.1"
   }
 }

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -1,0 +1,126 @@
+"use strict";
+
+import btoa from "btoa";
+import chai, { expect } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import sinon from "sinon";
+import Api from "../src";
+import { EventEmitter } from "events";
+import KintoServer from "./server_utils";
+
+chai.use(chaiAsPromised);
+chai.should();
+chai.config.includeStack = true;
+
+const TEST_KINTO_SERVER = "http://0.0.0.0:8888/v1";
+
+describe("Integration tests", () => {
+  let sandbox, server, api;
+
+  before(() => server = new KintoServer(TEST_KINTO_SERVER));
+
+  after(() => server.killAll());
+
+  beforeEach(function() {
+    this.timeout(12500);
+
+    sandbox = sinon.sandbox.create();
+    const events = new EventEmitter();
+    api = new Api(TEST_KINTO_SERVER, {
+      events,
+      headers: {Authorization: "Basic " + btoa("user:pass")}
+    });
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe("Default server configuration", () => {
+    before(() => server.start());
+
+    after(() => server.stop());
+
+    beforeEach(() => server.flush());
+
+    describe("Settings", () => {
+      it("should retrieve server settings", () => {
+        return api.fetchServerSettings()
+          .then(_ => api.serverSettings)
+          .should.eventually.have.property("batch_max_requests").eql(25);
+      });
+    });
+  });
+
+  describe("Flushed server", function() {
+    before(() => server.start());
+
+    after(() => server.stop());
+
+    beforeEach(() => server.flush());
+
+    it("should reject calls when a server flush is detected", () => {
+      return api.fetchChangesSince("default", "tasks", {lastModified: 1})
+        .should.be.rejectedWith(Error, "Server has been flushed");
+    });
+  });
+
+  describe("Backed off server", () => {
+    const backoffSeconds = 10;
+    before(() => server.start({CLIQUET_BACKOFF: backoffSeconds}));
+
+    after(() => server.stop());
+
+    beforeEach(() => server.flush());
+
+    it("should appropriately populate the backoff property", () => {
+      // Issuing a first api call to retrieve backoff information
+      return api.fetchChangesSince("default", "tasks")
+        .then(() => expect(Math.round(api.backoff / 1000)).eql(backoffSeconds));
+    });
+  });
+
+  describe("Deprecated protocol version", () => {
+    beforeEach(() => server.flush());
+
+    describe("Soft EOL", () => {
+      before(() => {
+        const tomorrow = new Date(new Date().getTime() + 86400000).toJSON().slice(0, 10);
+        return server.start({
+          CLIQUET_EOS: tomorrow,
+          CLIQUET_EOS_URL: "http://www.perdu.com",
+          CLIQUET_EOS_MESSAGE: "Boom",
+        });
+      });
+
+      after(() => server.stop());
+
+      beforeEach(() => sandbox.stub(console, "warn"));
+
+      it("should warn when the server sends a deprecation Alert header", () => {
+        return api.fetchServerSettings()
+          .then(_ => {
+            sinon.assert.calledWithExactly(console.warn, "Boom", "http://www.perdu.com");
+          });
+      });
+    });
+
+    describe("Hard EOL", () => {
+      before(() => {
+        const lastWeek = new Date(new Date().getTime() - (7 * 86400000)).toJSON().slice(0, 10);
+        return server.start({
+          CLIQUET_EOS: lastWeek,
+          CLIQUET_EOS_URL: "http://www.perdu.com",
+          CLIQUET_EOS_MESSAGE: "Boom",
+        });
+      });
+
+      after(() => server.stop());
+
+      beforeEach(() => sandbox.stub(console, "warn"));
+
+      it("should reject with a 410 Gone when hard EOL is received", () => {
+        return api.fetchServerSettings()
+          .should.be.rejectedWith(Error, /HTTP 410; Service deprecated/);
+      });
+    });
+  });
+});

--- a/test/kinto.ini
+++ b/test/kinto.ini
@@ -1,0 +1,56 @@
+[app:main]
+use = egg:kinto
+
+pyramid.debug_notfound = true
+
+cliquet.http_scheme = http
+cliquet.http_host = localhost:8888
+
+cliquet.project_name = kinto.js test server
+cliquet.project_docs = https://kinto.readthedocs.org/
+
+cliquet.basic_auth_enabled = true
+kinto.flush_endpoint_enabled = true
+
+#
+# Auth configuration.
+#
+cliquet.userid_hmac_secret = b4c96a8692291d88fe5a97dd91846eb4
+multiauth.policies = basicauth
+# multiauth.policies = fxa basicauth
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 8888
+
+# Begin logging configuration
+
+[loggers]
+keys = root, cliquet
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_cliquet]
+level = DEBUG
+handlers =
+qualname = cliquet
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
+
+# End logging configuration

--- a/test/kinto.ini
+++ b/test/kinto.ini
@@ -1,56 +1,14 @@
 [app:main]
 use = egg:kinto
 
-pyramid.debug_notfound = true
-
-cliquet.http_scheme = http
-cliquet.http_host = localhost:8888
-
-cliquet.project_name = kinto.js test server
-cliquet.project_docs = https://kinto.readthedocs.org/
-
-cliquet.basic_auth_enabled = true
+# Required by integration tests
 kinto.flush_endpoint_enabled = true
 
-#
-# Auth configuration.
-#
-cliquet.userid_hmac_secret = b4c96a8692291d88fe5a97dd91846eb4
-multiauth.policies = basicauth
-# multiauth.policies = fxa basicauth
+# Required by basic auth
+kinto.userid_hmac_secret = a-secret-string
+
 
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0
 port = 8888
-
-# Begin logging configuration
-
-[loggers]
-keys = root, cliquet
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[logger_cliquet]
-level = DEBUG
-handlers =
-qualname = cliquet
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/test/server_utils.js
+++ b/test/server_utils.js
@@ -1,0 +1,81 @@
+import { spawn } from "child_process";
+
+
+const DEFAULT_OPTIONS = {
+  maxAttempts: 50,
+  kintoConfigPath: __dirname + "/kinto.ini",
+  pservePath: process.env.KINTO_PSERVE_EXECUTABLE || "pserve",
+};
+
+export default class KintoServer {
+  constructor(url, options = {}) {
+    this.url = url;
+    this.process = null;
+    this.logs = [];
+    this.options = Object.assign({}, DEFAULT_OPTIONS, options);
+  }
+
+  start(env) {
+    if (this.process) {
+      throw new Error("Server is already started.");
+    }
+    return new Promise(resolve => {
+      // Add the provided environment variables to the child process environment.
+      // Keeping parent's environment is needed so that pserve's executable
+      // can be found (with PATH) if KINTO_PSERVE_EXECUTABLE env variable was
+      // not provided.
+      env = Object.assign({}, process.env, env);
+      this.process = spawn(
+        this.options.pservePath,
+        [this.options.kintoConfigPath],
+        {env, detached: true}
+      );
+      this.process.stderr.on("data", data => {
+        this.logs.push(data);
+      });
+      this.process.on("close", code => {
+        if (code && code > 0) {
+          throw new Error("Server errors encountered:\n" +
+            this.logs.map(line => line.toString()).join(""));
+        }
+      });
+      // Allow some time for the server to start.
+      setTimeout(resolve, 1000);
+    });
+  }
+
+  stop() {
+    this.process.kill();
+    this.process = null;
+    return new Promise(resolve => {
+      setTimeout(() => resolve(), 500);
+    });
+  }
+
+  flush(attempt = 1) {
+    return fetch(`${this.url}/__flush__`, {method: "POST"})
+      .then(res => {
+        if ([202, 410].indexOf(res.status) === -1) {
+          throw new Error("Unable to flush test server.");
+        }
+      })
+      .catch(err => {
+        // Prevent race condition where integration tests start while server
+        // isn't running yet.
+        if (/ECONNREFUSED/.test(err.message) &&
+            attempt < this.options.maxAttempts) {
+          return new Promise(resolve => {
+            setTimeout(_ => resolve(this.flush(attempt++)), 250);
+          });
+        }
+        throw err;
+      });
+  }
+
+  killAll() {
+    return new Promise((resolve) => {
+      spawn("killall", ["pserve"]).on("close", () => resolve());
+    });
+  }
+}
+


### PR DESCRIPTION
This sets up the integration environment using a real Kinto server.

Next steps are to extract the `KintoServer` test utility class to its own package so we can conveniently reuse it in Kinto.js as a dev dependency.

r=? @leplatrem 