### PR TITLE
Remove the babel dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "isomorphic-fetch": "^2.2.1"
   },
   "devDependencies": {
-    "babel": "^6.3.26",
     "babel-cli": "^6.4.5",
     "babel-core": "^6.3.26",
     "babel-eslint": "^5.0.0-beta6",


### PR DESCRIPTION
When trying to publish a new version of the package on npmjs.com, I had to run `npm run build` and `npm run dist`, I've had different issues:

1. Apparently there is a need to not install the `babel` package:

```
You have mistakenly installed the `babel` package, which is a no-op in Babel 6.
Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.

    npm uninstall babel
    npm install babel-cli

See http://babeljs.io/docs/usage/cli/ for setup instructions.
```
2. After doing this, a package was missing, I had to do `npm install line-numbers` manually.
3. Then, the binaries for babel and browserify weren't found, so I had to put the relative path to them.

Now, I'm not sure this is how it's supposed to be handled (I would prefer to find a way to let the name of binaries), so consider this as a discussion, and the PR as a way to describe what I had to do.