### PR TITLE
Fixes #27: Added support for options to Bucket and Collection.

### DIFF
--- a/test/chain_test.js
+++ b/test/chain_test.js
@@ -26,106 +26,219 @@ describe("chain module", () => {
   });
 
   describe("Bucket", () => {
-    let bucket;
+    function getBlogBucket(options) {
+      return new Bucket(client, "blog", options);
+    }
 
-    beforeEach(() => {
-      bucket = new Bucket(client, "blog");
+    describe("Options handling", () => {
+      it("should accept options", () => {
+        const options = {
+          headers: {Foo: "Bar"},
+          safe: true,
+        };
+        expect(getBlogBucket(options).options).eql(options);
+      });
     });
 
     describe("#collection", () => {
       it("should return a Collection instance", () => {
-        expect(bucket.collection("posts"))
+        expect(getBlogBucket().collection("posts"))
           .to.be.an.instanceOf(Collection);
       });
 
       it("should return a named collection", () => {
-        expect(bucket.collection("posts").name).eql("posts");
+        expect(getBlogBucket().collection("posts").name).eql("posts");
       });
     });
 
     describe("#listCollections()", () => {
-      it("should list bucket collections", () => {
+      beforeEach(() => {
         sandbox.stub(client, "listCollections");
+      });
 
-        bucket.listCollections();
+      it("should list bucket collections", () => {
+        getBlogBucket().listCollections();
 
         sinon.assert.calledWith(client.listCollections, "blog");
+      });
+
+      it("should merge default options", () => {
+        getBlogBucket({headers: {Foo: "Bar"}})
+          .listCollections({headers: {Baz: "Qux"}});
+
+        sinon.assert.calledWithMatch(client.listCollections, "blog", {
+          headers: {Foo: "Bar", Baz: "Qux"}
+        });
       });
     });
 
     describe("#createCollection()", () => {
+      beforeEach(() => {
+        sandbox.stub(client, "createCollection");
+      });
+
       describe("Named collection", () => {
         it("should create a named collection", () => {
-          sandbox.stub(client, "createCollection");
-
-          bucket.createCollection("foo");
+          getBlogBucket().createCollection("foo");
 
           sinon.assert.calledWith(client.createCollection, {
             bucket: "blog",
-            id: "foo"
+            id: "foo",
+            headers: {},
+          });
+        });
+
+        it("should merge default options", () => {
+          getBlogBucket({
+            headers: {Foo: "Bar"},
+            safe: true,
+          }).createCollection("foo", {headers: {Baz: "Qux"}});
+
+          sinon.assert.calledWithExactly(client.createCollection, {
+            bucket: "blog",
+            id: "foo",
+            headers: {Foo: "Bar", Baz: "Qux"},
+            safe: true,
           });
         });
       });
 
       describe("Unnamed collection", () => {
         it("should create an unnamed collection", () => {
-          sandbox.stub(client, "createCollection");
-
-          bucket.createCollection();
+          getBlogBucket().createCollection();
 
           sinon.assert.calledWith(client.createCollection, {
             bucket: "blog",
+            headers: {},
           });
         });
-      });
 
-      describe("#deleteCollection", () => {
-        it("should delete a collection", () => {
-          sandbox.stub(client, "deleteCollection");
+        it("should merge default options", () => {
+          getBlogBucket({
+            headers: {Foo: "Bar"},
+            safe: true,
+          }).createCollection({headers: {Baz: "Qux"}});
 
-          bucket.deleteCollection("todelete");
-
-          sinon.assert.calledWith(client.deleteCollection, "todelete", {
+          sinon.assert.calledWithExactly(client.createCollection, {
             bucket: "blog",
+            headers: {Foo: "Bar", Baz: "Qux"},
+            safe: true,
           });
         });
       });
+    });
 
-      describe("#getPermissions()", () => {
-        beforeEach(() => {
-          sandbox.stub(bucket, "getProperties").returns(Promise.resolve({
-            permissions: "fakeperms"
-          }));
-        });
+    describe("#deleteCollection", () => {
+      beforeEach(() => {
+        sandbox.stub(client, "deleteCollection");
+      });
 
-        it("should retrieve permissions", () => {
-          return bucket.getPermissions()
-            .should.become("fakeperms");
+      it("should delete a collection", () => {
+        getBlogBucket().deleteCollection("todelete");
+
+        sinon.assert.calledWith(client.deleteCollection, "todelete", {
+          bucket: "blog",
+          headers: {},
         });
       });
 
-      describe("#setPermissions()", () => {
-        it("should set permissions", () => {
-          sandbox.stub(client, "updateBucket");
+      it("should merge default options", () => {
+        getBlogBucket({
+          headers: {Foo: "Bar"},
+          safe: true,
+        }).deleteCollection("todelete", {headers: {Baz: "Qux"}});
 
-          bucket.setPermissions("fakeperms");
+        sinon.assert.calledWithExactly(client.deleteCollection, "todelete", {
+          bucket: "blog",
+          headers: {Foo: "Bar", Baz: "Qux"},
+          safe: true,
+        });
+      });
+    });
 
-          sinon.assert.calledWith(client.updateBucket, "blog", {}, {
-            permissions: "fakeperms"
+    describe("#getPermissions()", () => {
+      it("should retrieve permissions", () => {
+        const bucket = getBlogBucket();
+        sandbox.stub(bucket, "getProperties").returns(Promise.resolve({
+          permissions: "fakeperms"
+        }));
+
+        return bucket.getPermissions().should.become("fakeperms");
+      });
+
+      it("should merge default options", () => {
+        const bucket = getBlogBucket({
+          headers: {Foo: "Bar"},
+          safe: true,
+        });
+        sandbox.stub(bucket, "getProperties").returns(Promise.resolve({
+          permissions: "fakeperms"
+        }));
+
+        return bucket.getPermissions({headers: {Baz: "Qux"}}).then(_ => {
+          sinon.assert.calledWithMatch(bucket.getProperties, {
+            headers: {Foo: "Bar", Baz: "Qux"},
+            safe: true,
           });
         });
       });
+    });
 
-      describe("#batch()", () => {
-        it("should batch operations for this bucket", () => {
-          sandbox.stub(client, "batch");
-          const fn = batch => {};
+    describe("#setPermissions()", () => {
+      beforeEach(() => {
+        sandbox.stub(client, "updateBucket");
+      });
 
-          bucket.batch(fn);
+      it("should set permissions", () => {
+        getBlogBucket().setPermissions("fakeperms");
 
-          sinon.assert.calledWith(client.batch, fn, {
-            bucket: "blog"
-          });
+        sinon.assert.calledWithMatch(client.updateBucket, "blog", {}, {
+          permissions: "fakeperms"
+        });
+      });
+
+      it("should merge default options", () => {
+        getBlogBucket({
+          headers: {Foo: "Bar"},
+          safe: true,
+        }).setPermissions("fakeperms", {headers: {Baz: "Qux"}});
+
+        sinon.assert.calledWithMatch(client.updateBucket, "blog", {}, {
+          permissions: "fakeperms",
+          headers: {Foo: "Bar", Baz: "Qux"},
+          safe: true,
+        });
+      });
+    });
+
+    describe("#batch()", () => {
+      beforeEach(() => {
+        sandbox.stub(client, "batch");
+      });
+
+      it("should batch operations for this bucket", () => {
+        const fn = batch => {};
+
+        getBlogBucket().batch(fn);
+
+        sinon.assert.calledWith(client.batch, fn, {
+          bucket: "blog",
+          headers: {},
+        });
+      });
+
+      it("should merge default options", () => {
+        const fn = batch => {};
+
+        getBlogBucket({
+          headers: {Foo: "Bar"},
+          safe: true,
+        }).batch(fn, {headers: {Baz: "Qux"}});
+
+        sinon.assert.calledWithExactly(client.batch, fn, {
+          bucket: "blog",
+          headers: {Foo: "Bar", Baz: "Qux"},
+          safe: true,
         });
       });
     });

--- a/test/chain_test.js
+++ b/test/chain_test.js
@@ -40,7 +40,7 @@ describe("chain module", () => {
       });
     });
 
-    describe("#collection", () => {
+    describe("#collection()", () => {
       it("should return a Collection instance", () => {
         expect(getBlogBucket().collection("posts"))
           .to.be.an.instanceOf(Collection);
@@ -48,6 +48,20 @@ describe("chain module", () => {
 
       it("should return a named collection", () => {
         expect(getBlogBucket().collection("posts").name).eql("posts");
+      });
+
+      it("should propagate bucket options", () => {
+        expect(getBlogBucket({
+          headers: {Foo: "Bar"},
+          safe: true,
+        }).collection("posts", {
+          headers: {Baz: "Qux"},
+          safe: false,
+        }).options).eql({
+          bucket: "blog",
+          headers: {Foo: "Bar", Baz: "Qux"},
+          safe: false,
+        });
       });
     });
 
@@ -248,8 +262,8 @@ describe("chain module", () => {
     let coll;
 
     beforeEach(() => {
-      const bucket = new Bucket(client, "blog");
-      coll = new Collection(client, bucket, "posts");
+      const bucket = new Bucket(client, "blog", {headers: {Foo: "Bar"}});
+      coll = new Collection(client, bucket, "posts", {headers: {Baz: "Qux"}});
     });
 
     describe("#getPermissions()", () => {
@@ -273,7 +287,8 @@ describe("chain module", () => {
 
         sinon.assert.calledWith(client.updateCollection, "posts", {}, {
           bucket: "blog",
-          permissions: "fakeperms"
+          permissions: "fakeperms",
+          headers: {Foo: "Bar", Baz: "Qux"},
         });
       });
     });
@@ -303,7 +318,8 @@ describe("chain module", () => {
 
         sinon.assert.calledWith(client.updateCollection, "posts", {}, {
           bucket: "blog",
-          schema
+          schema,
+          headers: {Foo: "Bar", Baz: "Qux"},
         });
       });
     });
@@ -329,7 +345,8 @@ describe("chain module", () => {
 
         sinon.assert.calledWith(client.updateCollection, "posts", {a: 1}, {
           bucket: "blog",
-          patch: true
+          patch: true,
+          headers: {Foo: "Bar", Baz: "Qux"},
         });
       });
     });
@@ -343,7 +360,8 @@ describe("chain module", () => {
         coll.createRecord(record);
 
         sinon.assert.calledWith(client.createRecord, "posts", record, {
-          bucket: "blog"
+          bucket: "blog",
+          headers: {Foo: "Bar", Baz: "Qux"},
         });
       });
     });
@@ -357,7 +375,8 @@ describe("chain module", () => {
         coll.updateRecord(record);
 
         sinon.assert.calledWith(client.updateRecord, "posts", record, {
-          bucket: "blog"
+          bucket: "blog",
+          headers: {Foo: "Bar", Baz: "Qux"},
         });
       });
     });
@@ -369,7 +388,8 @@ describe("chain module", () => {
         coll.deleteRecord(1);
 
         sinon.assert.calledWith(client.deleteRecord, "posts", 1, {
-          bucket: "blog"
+          bucket: "blog",
+          headers: {Foo: "Bar", Baz: "Qux"},
         });
       });
     });
@@ -381,7 +401,8 @@ describe("chain module", () => {
         coll.getRecord(1);
 
         sinon.assert.calledWith(client.getRecord, "posts", 1, {
-          bucket: "blog"
+          bucket: "blog",
+          headers: {Foo: "Bar", Baz: "Qux"},
         });
       });
     });
@@ -398,7 +419,8 @@ describe("chain module", () => {
 
         sinon.assert.calledWith(client.listRecords, "posts", {
           bucket: "blog",
-          sort: "title"
+          sort: "title",
+          headers: {Foo: "Bar", Baz: "Qux"},
         });
       });
 
@@ -417,7 +439,8 @@ describe("chain module", () => {
 
         sinon.assert.calledWith(client.batch, fn, {
           bucket: "blog",
-          collection: "posts"
+          collection: "posts",
+          headers: {Foo: "Bar", Baz: "Qux"},
         });
       });
     });


### PR DESCRIPTION
Refs #27. Docs for TL;DRThePatchFully:
## Options

Both `bucket()` and `collection()` methods accept an `options` object as a second arguments where you can define the following options:

- `{Object} headers`: Custom headers to send along the request;
- `{Boolean} safe`: Ensure safe transactional operations; read more about that below.

Sample usage:

```js
client.bucket("blog", {
  headers: {"X-Hello": "Hello!"},
  safe: true
});
```

Here the `X-Hello` header and the `safe` option will be used for building every outgoing request sent to the server, for every collection attached to this bucket.

This works at the collection level as well:

```js
client.bucket("blog")
  .collection("posts", {
    headers: {"X-Hello": "Hello!"},
    safe: true
  });
```

Every request sent for this collection will have the options applied.

Last, you can of course pass these options at the atomic operation level:

```js
client.bucket("blog")
  .collection("posts")
  .updateRecord(updatedRecord, {
    headers: {"X-Hello": "Hello!"},
    safe: true
  });
```

The cool thing being you can always override the default defined options at the atomic operation level:

```js
client.bucket("blog", {safe: true})
  .collection("posts")
  .updateRecord(updatedRecord, {safe: false});
```

### The `safe` option explained

Enabling this option will ensure remote resources are never overriden if they've been modified since we first received them, raising an `HTTP 412` response describing the conflict when that happens:

```js
const updatedRecord = {
  id: "fbd2a565-8c10-497a-95b8-ce4ea6f474e1",
  title: "new post, modified",
  content: "yoyo",
  last_modified: 1456184189160
};

client.bucket("blog")
  .collection("posts")
  .updateRecord(updatedRecord, {safe: true});
```

If this record has been modified on the server already, meaning its `last_modified` is greater than the one we provide , we'll get a `412` error response.
