### PR TITLE
Paginate records list

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import { stringify as toQuerystring } from "querystring";
+
 /**
  * Returns the specified string with double quotes.
  *
@@ -94,4 +96,15 @@ export function toDataBody(value) {
     return {id: value};
   }
   throw new Error("Invalid collection argument.");
+}
+
+/**
+ * Transforms an object into an URL query string, stripping out any undefined
+ * values.
+ *
+ * @param  {Object} obj
+ * @return {String}
+ */
+export function qsify(obj) {
+  return toQuerystring(JSON.parse(JSON.stringify(obj)));
 }

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -2,7 +2,7 @@
 
 import chai, { expect } from "chai";
 
-import { quote, unquote, partition, pMap, omit } from "../src/utils";
+import { quote, unquote, partition, pMap, omit, qsify } from "../src/utils";
 
 chai.should();
 chai.config.includeStack = true;
@@ -79,6 +79,7 @@ describe("Utils", () => {
     });
   });
 
+  /** @test {omit} */
   describe("#omit", () => {
     it("should omit provided a single key", () => {
       expect(omit({a: 1, b: 2}, "a")).eql({b: 2});
@@ -90,6 +91,17 @@ describe("Utils", () => {
 
     it("should return source if no key is specified", () => {
       expect(omit({a: 1, b: 2})).eql({a: 1, b: 2});
+    });
+  });
+
+  /** @test {qsify} */
+  describe("#qsify", () => {
+    it("should generate a query string from an object", () => {
+      expect(qsify({a: 1, b: 2})).eql("a=1&b=2");
+    });
+
+    it("should strip out undefined values", () => {
+      expect(qsify({a: undefined, b: 2})).eql("b=2");
     });
   });
 });


### PR DESCRIPTION
This patch adds support for paginating the list of records.

**Note:** This changes the API for `Collection#listRecords`, as it now requires to resolve with an Object exposing the pagination API instead of the list of records directly.

Excerpt from added docs:

#### Pagination

All records are retrieved by default. To specify a max number of records to retrieve, you can use the `limit` option:

```js
client.bucket("blog").collection("posts")
  .listRecords({limit: 20})
  .then(result => ...);
```

To fetch the following batch of results, just call `next()` from the result object obtained. If no next page is available, `next()` throws an error you can catch to exit the flow:

```js
client.bucket("blog").collection("posts")
  .listRecords({limit: 20})
  .then(({data, next}) => {
    try {
      return next();
    } catch(err) {
      return data;
    }
  });
  .then(records => ...);
```

Last, if you just want to retrieve and aggregate a given number of pages of results, instead of dealing with calling `next()` recursively you can simply specify the `pages` option:

```js
client.bucket("blog").collection("posts")
  .listRecords({limit: 20, pages: 3})
  .then(records => ...); // A maximum of 60 records will be retrieved here