### PR TITLE
Closes #47: Added support for since to listRecords.

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ Sample result:
 
 ```js
 {
+  last_modified: "\"1456183930780\"",
   next: <Function>,
   data: [
     {
@@ -652,6 +653,8 @@ Sample result:
 }
 ```
 
+Note the root `last_modified` value which is the [collection's timestamp](http://kinto.readthedocs.org/en/latest/api/1.x/cliquet/timestamps.html). This value is opaque and should be reused as is, eg. passing it as a `since` option (see the *Options* section below).
+
 #### Sorting
 
 By default, records are listed by `last_modified` descending order. You can set the `sort` option to order by another field:
@@ -659,7 +662,17 @@ By default, records are listed by `last_modified` descending order. You can set 
 ```js
 client.bucket("blog").collection("posts")
   .listRecords({sort: "title"})
-  .then(result => ...);
+  .then(({data, next}) => {
+```
+
+#### Polling for changes
+
+To retrieve the list of records modified since a given timestamp, use the `since` option:
+
+```js
+client.bucket("blog").collection("posts")
+  .listRecords({since: "\"1456183930780\""})
+  .then(({data, next}) => {
 ```
 
 #### Pagination
@@ -669,7 +682,7 @@ By default, all records returned by the server are retrieved. To specify a max n
 ```js
 client.bucket("blog").collection("posts")
   .listRecords({limit: 20})
-  .then(result => ...);
+  .then(({data, next}) => {
 ```
 
 To retrieve the next page of records, just call `next()` from the result object obtained. If no next page is available, `next()` throws an error you can catch to exit the flow:
@@ -717,7 +730,7 @@ client.bucket("blog").collection("posts")
 - `filters`: An object defining the filters to apply; read more about [what's supported](http://kinto.readthedocs.org/en/latest/api/1.x/cliquet/resource.html#filtering);
 - `headers`: Custom headers object to send along the HTTP request;
 - `safe`: Ensures the resource hasn't been modified in the meanwhile if `last_modified` is provided (default: `false`);
-- `last_modified`: The last timestamp we know the resource has been updated on the server.
+- `since`: The ETag header value received from the last response from the server.
 
 ### Batching operations
 

--- a/src/requests.js
+++ b/src/requests.js
@@ -1,5 +1,4 @@
 import endpoint from "./endpoint";
-import { quote } from "./utils.js";
 
 
 const requestDefaults = {
@@ -23,7 +22,7 @@ function concurrencyCheck(safe, last_modified) {
   if (!last_modified) {
     throw new Error("Safe concurrency check requires a last_modified value.");
   }
-  return {"If-Match": quote(last_modified)};
+  return {"If-Match": `"${last_modified}"`};
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,28 +1,6 @@
 import { stringify as toQuerystring } from "querystring";
 
 /**
- * Returns the specified string with double quotes.
- *
- * @private
- * @param  {String} str  A string to quote.
- * @return {String}
- */
-export function quote(str) {
-  return `"${str}"`;
-}
-
-/**
- * Trim double quotes from specified string.
- *
- * @private
- * @param  {String} str  A string to unquote.
- * @return {String}
- */
-export function unquote(str) {
-  return str.replace(/^"/, "").replace(/"$/, "");
-}
-
-/**
  * Chunks an array into n pieces.
  *
  * @private

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -2,33 +2,12 @@
 
 import chai, { expect } from "chai";
 
-import { quote, unquote, partition, pMap, omit, qsify } from "../src/utils";
+import { partition, pMap, omit, qsify } from "../src/utils";
 
 chai.should();
 chai.config.includeStack = true;
 
 describe("Utils", () => {
-  /** @test {quote} */
-  describe("#quote", () => {
-    it("should add quotes to provided string", () => {
-      const quoted = quote("42");
-      expect(quoted).eql("\"42\"");
-    });
-  });
-
-  /** @test {unquote} */
-  describe("#unquote", () => {
-    it("should remove quotes to provided string", () => {
-      const unquoted = unquote("\"42\"");
-      expect(unquoted).eql("42");
-    });
-
-    it("should return the same string is not quoted", () => {
-      const unquoted = unquote("42");
-      expect(unquoted).eql("42");
-    });
-  });
-
   /** @test {partition} */
   describe("#partition", () => {
     it("should chunk array", () => {


### PR DESCRIPTION
r=? @leplatrem

### Listing records

```js
client.bucket("blog").collection("posts")
  .listRecords()
  .then(result => ...);
```

Sample result:

```js
{
  last_modified: "\"1456183930780\"",
  next: <Function>,
  data: [
    {
      "content": "True.",
      "last_modified": 1456183930780,
      "id": "a89dd4b2-d597-4192-bc2b-834116244d29",
      "title": "I love cheese"
    },
    {
      "content": "Yo",
      "last_modified": 1456183914275,
      "id": "63c1805a-565a-46cc-bfb3-007dfad54065",
      "title": "Another post"
    }
  ]
}
```

Note the root `last_modified` value which is the [collection's timestamp](http://kinto.readthedocs.org/en/latest/api/1.x/cliquet/timestamps.html). This value is opaque and should be reused as is, eg. passing it as a `since` option (see the *Options* section below).

#### Sorting

By default, records are listed by `last_modified` descending order. You can set the `sort` option to order by another field:

```js
client.bucket("blog").collection("posts")
  .listRecords({sort: "title"})
  .then(({data, next}) => {
```

#### Polling for changes

To retrieve the list of records modified since a given timestamp, use the `since` option:

```js
client.bucket("blog").collection("posts")
  .listRecords({since: "\"1456183930780\""})
  .then(({data, next}) => {
```

#### Pagination

By default, all records returned by the server are retrieved. To specify a max number of records to retrieve, you can use the `limit` option:

```js
client.bucket("blog").collection("posts")
  .listRecords({limit: 20})
  .then(({data, next}) => {
```

To retrieve the next page of records, just call `next()` from the result object obtained. If no next page is available, `next()` throws an error you can catch to exit the flow:

```js
let getNextPage;

client.bucket("blog").collection("posts")
  .listRecords({limit: 20})
  .then(({data, next}) => {
    console.log("Page 1", data);
    getNextPage = next;
  });
```

Later down the flow:

```js
getNextPage()
  .then(({data, next}) => {
    console.log("Page 2", data);
  })
  .catch(_ => {
    console.log("No more pages.");
  });
```

Last, if you just want to retrieve and aggregate a given number of result pages, instead of dealing with calling `next()` recursively you can simply specify the `pages` option:

```js
client.bucket("blog").collection("posts")
  .listRecords({limit: 20, pages: 3})
  .then(({data, next}) => ...); // A maximum of 60 records will be retrieved here
```

> ##### Notes
>
> If you plan on fetching all the available pages, you can set the `pages` option to `Infinity`. Be aware that for large datasets this strategy can possibly issue an important amount of HTTP requests.

#### Options

- `sort`: The order field (default: `-last_modified`);
- `pages`: The number of result pages to retrieve (default: `1`);
- `limit`: The number of records to retrieve per page: unset by default, uses default server configuration;
- `filters`: An object defining the filters to apply; read more about [what's supported](http://kinto.readthedocs.org/en/latest/api/1.x/cliquet/resource.html#filtering);
- `headers`: Custom headers object to send along the HTTP request;
- `safe`: Ensures the resource hasn't been modified in the meanwhile if `last_modified` is provided (default: `false`);
- `since`: The ETag header value received from the last response from the server.