### PR TITLE
Fixes #55: Fetch server settings on first issued HTTP request.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -200,7 +200,9 @@ export default class KintoClient {
     if (this.serverSettings) {
       return Promise.resolve(this.serverSettings);
     }
-    return this.execute({path: endpoint("root")})
+    return this.http.request(this.remote + endpoint("root"), {
+      headers: this.defaultReqOptions.headers
+    })
       .then(res => {
         this.serverSettings = res.json.settings;
         return this.serverSettings;
@@ -269,17 +271,20 @@ export default class KintoClient {
   }
 
   /**
-   * Executes an atomic request.
+   * Executes an atomic HTTP request.
    *
    * @private
    * @param  {Object} request The request object.
    * @return {Promise<Object, Error>}
    */
   execute(request) {
-    return this.http.request(this.remote + request.path, {
-      ...request,
-      body: JSON.stringify(request.body)
-    });
+    return this.fetchServerSettings()
+      .then(_ => {
+        return this.http.request(this.remote + request.path, {
+          ...request,
+          body: JSON.stringify(request.body)
+        });
+      });
   }
 
   /**

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -188,7 +188,7 @@ describe("KintoClient", () => {
 
       it("should ensure server settings are fetched", () => {
         return api.batch(batch => batch.createCollection())
-          .then(_ => sinon.assert.calledOnce(api.fetchServerSettings));
+          .then(_ => sinon.assert.called(api.fetchServerSettings));
       });
 
       describe("empty request list", () => {

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -522,11 +522,17 @@ describe("Collection", () => {
       it("should aggregate paginated results", () => {
         const { http } = coll.client;
         sandbox.stub(http, "request")
+          // settings retrieval
           .onFirstCall().returns(Promise.resolve({
+            json: {settings: {}}
+          }))
+          // first page
+          .onSecondCall().returns(Promise.resolve({
             headers: {get: () => "http://next-page/"},
             json: {data: [1, 2]}
           }))
-          .onSecondCall().returns(Promise.resolve({
+          // second page
+          .onThirdCall().returns(Promise.resolve({
             headers: {get: () => {}},
             json: {data: [3]}
           }));


### PR DESCRIPTION
I'm really challenging the benefits of this. Do we have an exhaustive list of exposed server settings documented somewhere, so we can accurately challenge future usefulness of this patch? /cc @leplatrem 