### PR TITLE
Fixes #57, #58, #59: Server config attribute getters.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,11 +71,11 @@ export default class KintoClient {
      */
     this.remote = remote;
     /**
-     * Current server settings, retrieved from the server.
+     * Current server information.
      * @ignore
-     * @type {Object}
+     * @type {Object|null}
      */
-    this.serverSettings = null;
+    this.serverInfo = null;
     /**
      * The event emitter instance. Should comply with the `EventEmitter`
      * interface.
@@ -192,21 +192,60 @@ export default class KintoClient {
   }
 
   /**
+   * Retrieves server information and persist them locally. This operation is
+   * usually performed a single time during the instance lifecycle.
+   *
+   * @return {Promise<Object, Error>}
+   */
+  fetchServerInfo() {
+    if (this.serverInfo) {
+      return Promise.resolve(this.serverInfo);
+    }
+    return this.http.request(this.remote + endpoint("root"), {
+      headers: this.defaultReqOptions.headers
+    })
+      .then(({json}) => {
+        this.serverInfo = json;
+        return this.serverInfo;
+      });
+  }
+
+  /**
    * Retrieves Kinto server settings.
    *
    * @return {Promise<Object, Error>}
    */
   fetchServerSettings() {
-    if (this.serverSettings) {
-      return Promise.resolve(this.serverSettings);
-    }
-    return this.http.request(this.remote + endpoint("root"), {
-      headers: this.defaultReqOptions.headers
-    })
-      .then(res => {
-        this.serverSettings = res.json.settings;
-        return this.serverSettings;
-      });
+    return this.fetchServerInfo().then(({settings}) => settings);
+  }
+
+  /**
+   * Retrieve server capabilities information.
+   *
+   * @return {Promise<Object, Error>}
+   */
+  fetchServerCapabilities() {
+    return this.fetchServerInfo().then(({capabilities}) => capabilities);
+  }
+
+  /**
+   * Retrieve authenticated user information.
+   *
+   * @return {Promise<Object, Error>}
+   */
+  fetchUser() {
+    return this.fetchServerInfo().then(({user}) => user);
+  }
+
+  /**
+   * Retrieve authenticated user information.
+   *
+   * @return {Promise<Object, Error>}
+   */
+  fetchHTTPApiVersion() {
+    return this.fetchServerInfo().then(({http_api_version}) => {
+      return http_api_version;
+    });
   }
 
   /**

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -134,32 +134,86 @@ describe("KintoClient", () => {
     });
   });
 
-  /** @test {KintoClient#fetchServerSettings} */
-  describe("#fetchServerSettings", () => {
-    it("should retrieve server settings on first request made", () => {
-      sandbox.stub(root, "fetch").returns(fakeServerResponse(200, {
-        settings: {"cliquet.batch_max_requests": 25}
-      }));
+  /** @test {KintoClient#fetchServerInfo} */
+  describe("#fetchServerInfo", () => {
+    const fakeServerInfo = {fake: true};
 
-      return api.fetchServerSettings()
-        .should.eventually.become({"cliquet.batch_max_requests": 25});
+    it("should retrieve server settings on first request made", () => {
+      sandbox.stub(root, "fetch")
+        .returns(fakeServerResponse(200, fakeServerInfo));
+
+      return api.fetchServerInfo()
+        .should.eventually.become(fakeServerInfo);
     });
 
     it("should store server settings into the serverSettings property", () => {
       api.serverSettings = {a: 1};
       sandbox.stub(root, "fetch");
 
-      api.fetchServerSettings();
+      api.fetchServerInfo();
     });
 
     it("should not fetch server settings if they're cached already", () => {
-      api.serverSettings = {a: 1};
+      api.serverInfo = fakeServerInfo;
       sandbox.stub(root, "fetch");
 
-      api.fetchServerSettings();
+      api.fetchServerInfo();
       sinon.assert.notCalled(fetch);
     });
   });
+
+  /** @test {KintoClient#fetchServerSettings} */
+  describe("#fetchServerSettings()", () => {
+    const fakeServerInfo = {settings: {fake: true}};
+
+    it("should retrieve server settings", () => {
+      sandbox.stub(root, "fetch")
+        .returns(fakeServerResponse(200, fakeServerInfo));
+
+      return api.fetchServerSettings()
+        .should.eventually.have.property("fake").eql(true);
+    });
+  });
+
+  /** @test {KintoClient#fetchServerCapabilities} */
+  describe("#fetchServerCapabilities()", () => {
+    const fakeServerInfo = {capabilities: {fake: true}};
+
+    it("should retrieve server capabilities", () => {
+      sandbox.stub(root, "fetch")
+        .returns(fakeServerResponse(200, fakeServerInfo));
+
+      return api.fetchServerCapabilities()
+        .should.eventually.have.property("fake").eql(true);
+    });
+  });
+
+  /** @test {KintoClient#fetchUser} */
+  describe("#fetchUser()", () => {
+    const fakeServerInfo = {user: {fake: true}};
+
+    it("should retrieve user information", () => {
+      sandbox.stub(root, "fetch")
+        .returns(fakeServerResponse(200, fakeServerInfo));
+
+      return api.fetchUser()
+        .should.eventually.have.property("fake").eql(true);
+    });
+  });
+
+  /** @test {KintoClient#fetchHTTPApiVersion} */
+  describe("#fetchHTTPApiVersion()", () => {
+    const fakeServerInfo = {http_api_version: {fake: true}};
+
+    it("should retrieve current API version", () => {
+      sandbox.stub(root, "fetch")
+        .returns(fakeServerResponse(200, fakeServerInfo));
+
+      return api.fetchHTTPApiVersion()
+        .should.eventually.have.property("fake").eql(true);
+    });
+  });
+
 
   /** @test {KintoClient#batch} */
   describe("#batch", () => {

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -53,11 +53,36 @@ describe("Integration tests", function() {
 
     beforeEach(() => server.flush());
 
-    describe("Settings", () => {
+    describe("Server properties", () => {
       it("should retrieve server settings", () => {
         return api.fetchServerSettings()
-          .then(_ => api.serverSettings)
           .should.eventually.have.property("batch_max_requests").eql(25);
+      });
+
+      it("should retrieve server capabilities", () => {
+        return api.fetchServerCapabilities()
+          .then(capabilities => {
+            expect(capabilities).to.be.an("object");
+
+            // Kinto protocol 1.4 exposes capability descriptions
+            Object.keys(capabilities).forEach(capability => {
+              const capabilityObj = capabilities[capability];
+              expect(capabilityObj).to.have.key("url", "description");
+            });
+          });
+      });
+
+      it("should retrieve user information", () => {
+        return api.fetchUser()
+          .then(user => {
+            expect(user.id).to.match(/^basicauth:/);
+            expect(user.bucket).to.have.length.of(36);
+          });
+      });
+
+      it("should retrieve current API version", () => {
+        return api.fetchHTTPApiVersion()
+          .should.eventually.match(/^\d\.\d+$/);
       });
     });
 


### PR DESCRIPTION
This patch exposes new methods to lazily retrieve and cache exposed server configuration:

- `#fetchCapabilities()` resolves with the server `capabilities` object.
- `#fetchUser()` resolves with the server `user` object.
- `#fetchHTTPApiVersion()` resolves with the server `http_api_version` object.
- `#fetchServerSettings()` works as before.

r=? @leplatrem 