### PR TITLE
Fixes #62: Check for http_api_version compatibility.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["es2015"],
+  "presets": ["es2015", "decorators-legacy"],
   "plugins": ["transform-object-rest-spread"]
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.6.5",
     "babel-plugin-transform-object-rest-spread": "^6.5.5",
     "babel-polyfill": "^6.6.1",
+    "babel-preset-decorators-legacy": "^1.0.0",
     "babel-preset-es2015": "^6.6.0",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -391,4 +391,19 @@ export default class KintoClient {
     return this.execute(requests.deleteBucket(_bucket, reqOptions))
       .then(res => res.json);
   }
+
+  /**
+   * Deletes all buckets on the server.
+   *
+   * @ignore
+   * @param  {Object}        options         The options object.
+   * @param  {Boolean}       options.safe    The safe option.
+   * @param  {Object}        options.headers The headers object option.
+   * @return {Promise<Object, Error>}
+   */
+  deleteBuckets(options={}) {
+    const reqOptions = this._getRequestOptions(options);
+    return this.execute(requests.deleteBuckets(reqOptions))
+      .then(res => res.json);
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 import "isomorphic-fetch";
 import { EventEmitter } from "events";
 
-import { partition, pMap, omit } from "./utils";
+import { partition, pMap, omit, checkVersion } from "./utils";
 import HTTP from "./http";
 import endpoint from "./endpoint";
 import * as requests from "./requests";
@@ -149,6 +149,25 @@ export default class KintoClient {
     this.events.on("backoff", backoffMs => {
       this._backoffReleaseTime = backoffMs;
     });
+  }
+
+  /**
+   * Conditionnaly executes provided function if current server http_api_version
+   * supports it and returns a Promise resolving with its result when the
+   * condition is satisfied, rejects when it's not.
+   *
+   * @ignore
+   * @param  {String}   min  The minimum protocol version required (inclusive).
+   * @param  {String}   max  The maximum protocol version required (exclusive).
+   * @param  {Function} fn   The function to resolve with.
+   * @return {Promise<Object, Error>}
+   */
+  ensureSupported(min, max, fn) {
+    return this.fetchHTTPApiVersion()
+      .then(currentVersion => {
+        checkVersion(currentVersion, min, max);
+        return fn();
+      });
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 import "isomorphic-fetch";
 import { EventEmitter } from "events";
 
-import { partition, pMap, omit, checkVersion, support } from "./utils";
+import { partition, pMap, omit, support } from "./utils";
 import HTTP from "./http";
 import endpoint from "./endpoint";
 import * as requests from "./requests";
@@ -149,22 +149,6 @@ export default class KintoClient {
     this.events.on("backoff", backoffMs => {
       this._backoffReleaseTime = backoffMs;
     });
-  }
-
-  /**
-   * Checks if current server http_api_version matches the provided min and max
-   * version requirements; returns a Promise resolving when the version is
-   * within range, rejecting when it's not.
-   *
-   * @ignore
-   * @param  {String}   min  The minimum protocol version required (inclusive).
-   * @param  {String}   max  The maximum protocol version required (exclusive).
-   * @param  {Function} fn   The function to resolve with.
-   * @return {Promise<Object, Error>}
-   */
-  ensureSupported(min, max) {
-    return this.fetchHTTPApiVersion()
-      .then(version => checkVersion(version, min, max));
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 import "isomorphic-fetch";
 import { EventEmitter } from "events";
 
-import { partition, pMap, omit, checkVersion } from "./utils";
+import { partition, pMap, omit, checkVersion, support } from "./utils";
 import HTTP from "./http";
 import endpoint from "./endpoint";
 import * as requests from "./requests";
@@ -398,12 +398,10 @@ export default class KintoClient {
    * @param  {Object}  options.headers The headers object option.
    * @return {Promise<Object, Error>}
    */
+  @support("1.4", "2.0")
   deleteBuckets(options={}) {
-    return this.ensureSupported("1.4", "2.0")
-      .then(_ => {
-        const reqOptions = this._getRequestOptions(options);
-        return this.execute(requests.deleteBuckets(reqOptions));
-      })
+    const reqOptions = this._getRequestOptions(options);
+    return this.execute(requests.deleteBuckets(reqOptions))
       .then(res => res.json);
   }
 }

--- a/src/requests.js
+++ b/src/requests.js
@@ -101,6 +101,24 @@ export function deleteBucket(bucket, options = {}) {
 /**
  * @private
  */
+export function deleteBuckets(options = {}) {
+  const { headers, safe, last_modified} = {
+    ...requestDefaults,
+    ...options
+  };
+  if (safe && !last_modified) {
+    throw new Error("Safe concurrency check requires a last_modified value.");
+  }
+  return {
+    method: "DELETE",
+    path: endpoint("buckets"),
+    headers: {...headers, ...safeHeader(safe, last_modified)},
+  };
+}
+
+/**
+ * @private
+ */
 export function createCollection(id, options = {}) {
   const { bucket, headers, permissions, data, safe } = {
     ...requestDefaults,

--- a/src/utils.js
+++ b/src/utils.js
@@ -109,10 +109,15 @@ export function checkVersion(version, min, max) {
   if (verMajor < minMajor) {
     throw new Error(msg);
   }
-  if (verMinor < minMinor) {
-    throw new Error(msg);
+  if (verMajor === minMajor) {
+    if (verMinor < minMinor) {
+      throw new Error(msg);
+    }
   }
   if (verMajor >= maxMajor) {
+    if (verMajor > maxMajor) {
+      throw new Error(msg);
+    }
     if (verMinor >= maxMinor) {
       throw new Error(msg);
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -127,7 +127,9 @@ export function support(min, max) {
       configurable: true,
       get() {
         const wrappedMethod = (...args) => {
-          return this.ensureSupported(min, max).then(fn.apply(this, args));
+          return this.fetchHTTPApiVersion()
+            .then(version => checkVersion(version, min, max))
+            .then(fn.apply(this, args));
         };
         Object.defineProperty(this, key, {
           value: wrappedMethod,

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,8 +91,8 @@ export function qsify(obj) {
  * Checks if a version is within the provided range.
  *
  * @param  {String} version    The version to check.
- * @param  {String} minVersion The minimum version (inclusive).
- * @param  {String} maxVersion The minimum version (exclusive).
+ * @param  {String} minVersion The minimum supported version (inclusive).
+ * @param  {String} maxVersion The minimum supported version (exclusive).
  * @throws {Error} If the version is outside of the provided range.
  */
 export function checkVersion(version, minVersion, maxVersion) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -86,3 +86,35 @@ export function toDataBody(value) {
 export function qsify(obj) {
   return toQuerystring(JSON.parse(JSON.stringify(obj)));
 }
+
+/**
+ * Checks if a version is within the provided range.
+ *
+ * @param  {String} version The version to check.
+ * @param  {String} min     The minimum version (inclusive).
+ * @param  {String} max     The minimum version (exclusive).
+ * @throws {Error} If the version is outside of the provided range.
+ */
+export function checkVersion(version, min, max) {
+  function extract(str) {
+    return str.split(".").map(x => parseInt(x, 10));
+  }
+
+  const [verMajor, verMinor] = extract(version);
+  const [minMajor, minMinor] = extract(min);
+  const [maxMajor, maxMinor] = extract(max);
+
+  const msg = `Version ${version} doesn't match ${min} <= x < ${max}`;
+
+  if (verMajor < minMajor) {
+    throw new Error(msg);
+  }
+  if (verMinor < minMinor) {
+    throw new Error(msg);
+  }
+  if (verMajor >= maxMajor) {
+    if (verMinor >= maxMinor) {
+      throw new Error(msg);
+    }
+  }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -129,7 +129,7 @@ export function support(min, max) {
         const wrappedMethod = (...args) => {
           return this.fetchHTTPApiVersion()
             .then(version => checkVersion(version, min, max))
-            .then(fn.apply(this, args));
+            .then(Promise.resolve(fn.apply(this, args)));
         };
         Object.defineProperty(this, key, {
           value: wrappedMethod,

--- a/src/utils.js
+++ b/src/utils.js
@@ -111,3 +111,31 @@ export function checkVersion(version, min, max) {
     throw new Error(msg);
   }
 }
+
+/**
+ * Generates a decorator function ensuring a version check is performed against
+ * the provided requirements before executing it.
+ *
+ * @param  {String} min The required min version (inclusive).
+ * @param  {String} max The required max version (inclusive).
+ * @return {Function}
+ */
+export function support(min, max) {
+  return function(target, key, descriptor) {
+    const fn = descriptor.value;
+    return {
+      configurable: true,
+      get() {
+        const wrappedMethod = (...args) => {
+          return this.ensureSupported(min, max).then(fn.apply(this, args));
+        };
+        Object.defineProperty(this, key, {
+          value: wrappedMethod,
+          configurable: true,
+          writable: true
+        });
+        return wrappedMethod;
+      }
+    };
+  };
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -96,10 +96,7 @@ export function qsify(obj) {
  * @throws {Error} If the version is outside of the provided range.
  */
 export function checkVersion(version, min, max) {
-  function extract(str) {
-    return str.split(".").map(x => parseInt(x, 10));
-  }
-
+  const extract = (str) => str.split(".").map(x => parseInt(x, 10));
   const [verMajor, verMinor] = extract(version);
   const [minMajor, minMinor] = extract(min);
   const [maxMajor, maxMinor] = extract(max);

--- a/src/utils.js
+++ b/src/utils.js
@@ -100,23 +100,14 @@ export function checkVersion(version, min, max) {
   const [verMajor, verMinor] = extract(version);
   const [minMajor, minMinor] = extract(min);
   const [maxMajor, maxMinor] = extract(max);
-
   const msg = `Version ${version} doesn't match ${min} <= x < ${max}`;
-
-  if (verMajor < minMajor) {
+  const checks = [
+    verMajor < minMajor,
+    verMajor === minMajor && verMinor < minMinor,
+    verMajor > maxMajor,
+    verMajor === maxMajor && verMinor >= maxMinor,
+  ];
+  if (checks.some(x => x)) {
     throw new Error(msg);
-  }
-  if (verMajor === minMajor) {
-    if (verMinor < minMinor) {
-      throw new Error(msg);
-    }
-  }
-  if (verMajor >= maxMajor) {
-    if (verMajor > maxMajor) {
-      throw new Error(msg);
-    }
-    if (verMinor >= maxMinor) {
-      throw new Error(msg);
-    }
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -90,17 +90,16 @@ export function qsify(obj) {
 /**
  * Checks if a version is within the provided range.
  *
- * @param  {String} version The version to check.
- * @param  {String} min     The minimum version (inclusive).
- * @param  {String} max     The minimum version (exclusive).
+ * @param  {String} version    The version to check.
+ * @param  {String} minVersion The minimum version (inclusive).
+ * @param  {String} maxVersion The minimum version (exclusive).
  * @throws {Error} If the version is outside of the provided range.
  */
-export function checkVersion(version, min, max) {
+export function checkVersion(version, minVersion, maxVersion) {
   const extract = (str) => str.split(".").map(x => parseInt(x, 10));
   const [verMajor, verMinor] = extract(version);
-  const [minMajor, minMinor] = extract(min);
-  const [maxMajor, maxMinor] = extract(max);
-  const msg = `Version ${version} doesn't match ${min} <= x < ${max}`;
+  const [minMajor, minMinor] = extract(minVersion);
+  const [maxMajor, maxMinor] = extract(maxVersion);
   const checks = [
     verMajor < minMajor,
     verMajor === minMajor && verMinor < minMinor,
@@ -108,7 +107,8 @@ export function checkVersion(version, min, max) {
     verMajor === maxMajor && verMinor >= maxMinor,
   ];
   if (checks.some(x => x)) {
-    throw new Error(msg);
+    throw new Error(`Version ${version} doesn't satisfy ` +
+                    `${minVersion} <= x < ${maxVersion}`);
   }
 }
 

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -667,4 +667,39 @@ describe("KintoClient", () => {
       });
     });
   });
+
+  /** @test {KintoClient#deleteBuckets} */
+  describe("#deleteBuckets()", () => {
+    beforeEach(() => {
+      sandbox.stub(requests, "deleteBuckets");
+      sandbox.stub(api, "execute").returns(Promise.resolve());
+    });
+
+    it("should execute expected request", () => {
+      api.deleteBuckets();
+
+      sinon.assert.calledWithMatch(requests.deleteBuckets, {
+        headers: {},
+        safe: false,
+      });
+    });
+
+    it("should accept a safe option", () => {
+      api.deleteBuckets({safe: true});
+
+      sinon.assert.calledWithMatch(requests.deleteBuckets, {
+        safe: true
+      });
+    });
+
+    it("should extend request headers with optional ones", () => {
+      api.defaultReqOptions.headers = {Foo: "Bar"};
+
+      api.deleteBuckets({headers: {Baz: "Qux"}});
+
+      sinon.assert.calledWithMatch(requests.deleteBuckets, {
+        headers: {Foo: "Bar", Baz: "Qux"}
+      });
+    });
+  });
 });

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -216,37 +216,17 @@ describe("KintoClient", () => {
 
   /** @test {KintoClient#ensureSupported} */
   describe("#ensureSupported()", () => {
-    describe("Supported http_api_version", () => {
-      it("should execute a function when http_api_version is supported", () => {
-        api.serverInfo = {http_api_version: "1.4"};
-        const spy = sandbox.spy();
-
-        return api.ensureSupported("1.0", "2.0", spy)
-          .then(_ => {
-            sinon.assert.called(spy);
-          });
-      });
+    it("should resolve when http_api_version is supported", () => {
+      api.serverInfo = {http_api_version: "1.4"};
+      return api.ensureSupported("1.0", "2.0")
+        .should.be.fulfilled;
     });
 
-    describe("Unsupported http_api_version version", () => {
-      beforeEach(() => {
-        api.serverInfo = {http_api_version: "1.3"};
-      });
-
-      it("should reject when http_api_version is not supported", () => {
-        return api.ensureSupported("1.4", "2.0", () => {})
-          .should.be.rejectedWith(Error,
-            "Version 1.3 doesn't match 1.4 <= x < 2.0");
-      });
-
-      it("should not execute a function when http_api_version is not supported", () => {
-        const spy = sandbox.spy();
-
-        return api.ensureSupported("1.4", "2.0", spy)
-          .catch(_ => {
-            sinon.assert.notCalled(spy);
-          });
-      });
+    it("should reject when http_api_version is not supported", () => {
+      api.serverInfo = {http_api_version: "1.3"};
+      return api.ensureSupported("1.4", "2.0")
+        .should.be.rejectedWith(Error,
+          "Version 1.3 doesn't match 1.4 <= x < 2.0");
     });
   });
 
@@ -671,35 +651,41 @@ describe("KintoClient", () => {
   /** @test {KintoClient#deleteBuckets} */
   describe("#deleteBuckets()", () => {
     beforeEach(() => {
+      api.serverInfo = {http_api_version: "1.4"};
       sandbox.stub(requests, "deleteBuckets");
-      sandbox.stub(api, "execute").returns(Promise.resolve());
+      sandbox.stub(api, "execute").returns(Promise.resolve({
+        json: {}
+      }));
     });
 
     it("should execute expected request", () => {
-      api.deleteBuckets();
-
-      sinon.assert.calledWithMatch(requests.deleteBuckets, {
-        headers: {},
-        safe: false,
-      });
+      return api.deleteBuckets()
+        .then(_ => {
+          sinon.assert.calledWithMatch(requests.deleteBuckets, {
+            headers: {},
+            safe: false,
+          });
+        });
     });
 
     it("should accept a safe option", () => {
-      api.deleteBuckets({safe: true});
-
-      sinon.assert.calledWithMatch(requests.deleteBuckets, {
-        safe: true
-      });
+      return api.deleteBuckets({safe: true})
+        .then(_ => {
+          sinon.assert.calledWithMatch(requests.deleteBuckets, {
+            safe: true
+          });
+        });
     });
 
     it("should extend request headers with optional ones", () => {
       api.defaultReqOptions.headers = {Foo: "Bar"};
 
-      api.deleteBuckets({headers: {Baz: "Qux"}});
-
-      sinon.assert.calledWithMatch(requests.deleteBuckets, {
-        headers: {Foo: "Bar", Baz: "Qux"}
-      });
+      return api.deleteBuckets({headers: {Baz: "Qux"}})
+        .then(_ => {
+          sinon.assert.calledWithMatch(requests.deleteBuckets, {
+            headers: {Foo: "Bar", Baz: "Qux"}
+          });
+        });
     });
   });
 });

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -214,22 +214,6 @@ describe("KintoClient", () => {
     });
   });
 
-  /** @test {KintoClient#ensureSupported} */
-  describe("#ensureSupported()", () => {
-    it("should resolve when http_api_version is supported", () => {
-      api.serverInfo = {http_api_version: "1.4"};
-      return api.ensureSupported("1.0", "2.0")
-        .should.be.fulfilled;
-    });
-
-    it("should reject when http_api_version is not supported", () => {
-      api.serverInfo = {http_api_version: "1.3"};
-      return api.ensureSupported("1.4", "2.0")
-        .should.be.rejectedWith(Error,
-          "Version 1.3 doesn't match 1.4 <= x < 2.0");
-    });
-  });
-
   /** @test {KintoClient#batch} */
   describe("#batch", () => {
     beforeEach(() => {

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -214,6 +214,41 @@ describe("KintoClient", () => {
     });
   });
 
+  /** @test {KintoClient#ensureSupported} */
+  describe("#ensureSupported()", () => {
+    describe("Supported http_api_version", () => {
+      it("should execute a function when http_api_version is supported", () => {
+        api.serverInfo = {http_api_version: "1.4"};
+        const spy = sandbox.spy();
+
+        return api.ensureSupported("1.0", "2.0", spy)
+          .then(_ => {
+            sinon.assert.called(spy);
+          });
+      });
+    });
+
+    describe("Unsupported http_api_version version", () => {
+      beforeEach(() => {
+        api.serverInfo = {http_api_version: "1.3"};
+      });
+
+      it("should reject when http_api_version is not supported", () => {
+        return api.ensureSupported("1.4", "2.0", () => {})
+          .should.be.rejectedWith(Error,
+            "Version 1.3 doesn't match 1.4 <= x < 2.0");
+      });
+
+      it("should not execute a function when http_api_version is not supported", () => {
+        const spy = sandbox.spy();
+
+        return api.ensureSupported("1.4", "2.0", spy)
+          .catch(_ => {
+            sinon.assert.notCalled(spy);
+          });
+      });
+    });
+  });
 
   /** @test {KintoClient#batch} */
   describe("#batch", () => {

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -671,5 +671,12 @@ describe("KintoClient", () => {
           });
         });
     });
+
+    it("should reject if http_api_version mismatches", () => {
+      api.serverInfo = {http_api_version: "1.3"};
+
+      return api.deleteBuckets()
+        .should.be.rejectedWith(Error, /Version/);
+    });
   });
 });

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -9,6 +9,7 @@ import Api from "../src";
 import { checkVersion } from "../src/utils";
 import { EventEmitter } from "events";
 import KintoServer from "./server_utils";
+import { delayedPromise } from "./test_utils";
 
 chai.use(chaiAsPromised);
 chai.should();
@@ -174,6 +175,9 @@ describe("Integration tests", function() {
 
       it("should delete all buckets", () => {
         return api.deleteBuckets()
+          // Note: Server tends to take a lot of time to perform this operation,
+          // so we're delaying check a little.
+          .then(_ => delayedPromise(50))
           .then(_ => api.listBuckets())
           .then(({data}) => data)
           .should.become([]);

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -6,6 +6,7 @@ import chaiAsPromised from "chai-as-promised";
 import sinon from "sinon";
 
 import Api from "../src";
+import { checkVersion } from "../src/utils";
 import { EventEmitter } from "events";
 import KintoServer from "./server_utils";
 
@@ -152,6 +153,30 @@ describe("Integration tests", function() {
           })
             .should.be.rejectedWith(Error, /412 Precondition Failed/);
         });
+      });
+    });
+
+    describe("#deleteBuckets()", () => {
+      before(function() {
+        try {
+          checkVersion(server.http_api_version, "1.4", "2.0");
+        } catch(err) {
+          this.skip();
+        }
+      });
+
+      beforeEach(() => {
+        return api.batch(batch => {
+          batch.createBucket("b1");
+          batch.createBucket("b2");
+        });
+      });
+
+      it("should delete all buckets", () => {
+        return api.deleteBuckets()
+          .then(_ => api.listBuckets())
+          .then(({data}) => data)
+          .should.become([]);
       });
     });
 

--- a/test/requests_test.js
+++ b/test/requests_test.js
@@ -78,6 +78,32 @@ describe("requests module", () => {
     });
   });
 
+  describe("#deleteBuckets()", () => {
+    it("should return a bucket deletion request when an id is provided", () => {
+      expect(requests.deleteBuckets()).eql({
+        headers: {},
+        method: "DELETE",
+        path: "/buckets",
+      });
+    });
+
+    it("should accept a headers option", () => {
+      expect(requests.deleteBuckets({headers: {Foo: "Bar"}}))
+        .to.have.property("headers").eql({Foo: "Bar"});
+    });
+
+    it("should raise for safe with no last_modified passed", () => {
+      expect(() => requests.deleteBuckets({safe: true}))
+        .to.Throw(Error, /requires a last_modified/);
+    });
+
+    it("should support a safe option with a last_modified option", () => {
+      expect(requests.deleteBuckets({safe: true, last_modified: 42}))
+        .to.have.property("headers")
+        .to.have.property("If-Match").eql("\"42\"");
+    });
+  });
+
   describe("createCollection()", () => {
     it("should return a collection creation request when an id is provided", () => {
       expect(requests.createCollection("foo")).eql({

--- a/test/server_utils.js
+++ b/test/server_utils.js
@@ -12,6 +12,7 @@ export default class KintoServer {
     this.url = url;
     this.process = null;
     this.logs = [];
+    this.http_api_version = null;
     this.options = Object.assign({}, DEFAULT_OPTIONS, options);
   }
 
@@ -22,6 +23,7 @@ export default class KintoServer {
         if ([200, 202, 410].indexOf(res.status) === -1) {
           throw new Error("Unable to start server, HTTP " + res.status);
         }
+        return res;
       })
       .catch(err => {
         if (attempt < maxAttempts) {
@@ -64,7 +66,9 @@ export default class KintoServer {
 
   ping() {
     const endpoint = `${this.url}/`;
-    return this._retryRequest(endpoint, {}, 1);
+    return this._retryRequest(endpoint, {}, 1)
+      .then(res => res.json())
+      .then(json => this.http_api_version = json.http_api_version);
   }
 
   flush(attempt = 1) {

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -16,3 +16,9 @@ export function fakeServerResponse(status, json, headers={}) {
     }
   });
 }
+
+export function delayedPromise(ms) {
+  return new Promise(resolve => {
+    setTimeout(() => resolve(), ms);
+  });
+}

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -2,7 +2,14 @@
 
 import chai, { expect } from "chai";
 
-import { partition, pMap, omit, qsify, checkVersion } from "../src/utils";
+import {
+  partition,
+  pMap,
+  omit,
+  qsify,
+  checkVersion,
+  support
+} from "../src/utils";
 
 chai.should();
 chai.config.includeStack = true;
@@ -100,6 +107,57 @@ describe("Utils", () => {
       expect(() => checkVersion("2.1", "1.0", "2.0")).to.Throw(Error);
       expect(() => checkVersion("3.9", "1.0", "2.10")).to.Throw(Error);
       expect(() => checkVersion("1.3", "1.4", "2.0")).to.Throw(Error);
+    });
+  });
+
+  describe("@support", () => {
+    it("should return a function", () => {
+      expect(support()).to.be.a("function");
+    });
+
+    it("should make decorated method checking the version", () => {
+      class FakeClient {
+        fetchHTTPApiVersion() {
+          return Promise.resolve(); // simulates a successful checkVersion call
+        }
+
+        @support()
+        test() {
+          return Promise.resolve();
+        }
+      }
+
+      return new FakeClient().test().should.be.fullfilled;
+    });
+
+    it("should make decorated method resolve on version match", () => {
+      class FakeClient {
+        fetchHTTPApiVersion() {
+          return Promise.resolve(); // simulates a successful checkVersion call
+        }
+
+        @support()
+        test() {
+          return Promise.resolve();
+        }
+      }
+
+      return new FakeClient().test().should.be.fullfilled;
+    });
+
+    it("should make decorated method rejecting on version mismatch", () => {
+      class FakeClient {
+        fetchHTTPApiVersion() {
+          return Promise.reject(); // simulates a failing checkVersion call
+        }
+
+        @support()
+        test() {
+          return Promise.resolve();
+        }
+      }
+
+      return new FakeClient().test().should.be.rejected;
     });
   });
 });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -84,18 +84,22 @@ describe("Utils", () => {
     });
   });
 
-  describe("#checkVersion", () => {
+  describe.only("#checkVersion", () => {
     it("should accept a version within provided range", () => {
       checkVersion("1.0", "1.0", "2.0");
       checkVersion("1.10", "1.0", "2.0");
       checkVersion("1.10", "1.9", "2.0");
       checkVersion("2.1", "1.0", "2.2");
+      checkVersion("2.1", "1.2", "2.2");
+      checkVersion("1.4", "1.4", "2.0");
     });
 
     it("should not accept a version oustide provided range", () => {
       expect(() => checkVersion("0.9", "1.0", "2.0")).to.Throw(Error);
       expect(() => checkVersion("2.0", "1.0", "2.0")).to.Throw(Error);
       expect(() => checkVersion("2.1", "1.0", "2.0")).to.Throw(Error);
+      expect(() => checkVersion("3.9", "1.0", "2.10")).to.Throw(Error);
+      expect(() => checkVersion("1.3", "1.4", "2.0")).to.Throw(Error);
     });
   });
 });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -84,7 +84,7 @@ describe("Utils", () => {
     });
   });
 
-  describe.only("#checkVersion", () => {
+  describe("#checkVersion", () => {
     it("should accept a version within provided range", () => {
       checkVersion("1.0", "1.0", "2.0");
       checkVersion("1.10", "1.0", "2.0");

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -2,7 +2,7 @@
 
 import chai, { expect } from "chai";
 
-import { partition, pMap, omit, qsify } from "../src/utils";
+import { partition, pMap, omit, qsify, checkVersion } from "../src/utils";
 
 chai.should();
 chai.config.includeStack = true;
@@ -81,6 +81,21 @@ describe("Utils", () => {
 
     it("should strip out undefined values", () => {
       expect(qsify({a: undefined, b: 2})).eql("b=2");
+    });
+  });
+
+  describe("#checkVersion", () => {
+    it("should accept a version within provided range", () => {
+      checkVersion("1.0", "1.0", "2.0");
+      checkVersion("1.10", "1.0", "2.0");
+      checkVersion("1.10", "1.9", "2.0");
+      checkVersion("2.1", "1.0", "2.2");
+    });
+
+    it("should not accept a version oustide provided range", () => {
+      expect(() => checkVersion("0.9", "1.0", "2.0")).to.Throw(Error);
+      expect(() => checkVersion("2.0", "1.0", "2.0")).to.Throw(Error);
+      expect(() => checkVersion("2.1", "1.0", "2.0")).to.Throw(Error);
     });
   });
 });


### PR DESCRIPTION
This is WiP, refs #62.

The patch introduces a `ensureSupported` method at the client level we can leverage to conditionally execute a function depending of HTTP API version requirements.

This also adds `KintoClient#deleteBuckets()` which is provided by the Kinto protocol v1.4 only, and conditional integration tests for it. 

Feedback=? @almet @Natim @leplatrem @magopian 

PS: Discarded using ES7 decorators. I really wish decorated methods could access their related instance state, though we're only passed the class itself, which is pointless except if you want to attach static properties to it (which you don't). Also, fought too hard with Babel to be confident using them securely.

Edit: Finally managed to use ES7 decorators. Much better.