### PR TITLE
Bump v0.5.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kinto-client",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "JavaScript HTTP client for the Kinto API.",
   "main": "lib/index.js",
   "scripts": {
@@ -9,7 +9,7 @@
     "dist-dev": "browserify -s KintoClient -d -e src/index.js -o dist/kinto-client.js -t [ babelify --sourceMapRelative . ]",
     "dist-noshim": "browserify -s KintoClient -g uglifyify --ignore isomorphic-fetch --ignore babel-polyfill -e src/index.js -o dist/kinto-client.noshim.js -t [ babelify --sourceMapRelative . ]",
     "dist-prod": "browserify -s KintoClient -g uglifyify -e src/index.js -o dist/kinto-client.min.js -t [ babelify --sourceMapRelative . ]",
-    "pusblish-to-npm": "npm run build && npm run dist && npm publish",
+    "publish-to-npm": "npm run build && npm run dist && npm publish",
     "report-coverage": "npm run test-cover && ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info",
     "tdd": "babel-node node_modules/.bin/_mocha --watch 'test/**/*_test.js'",
     "test": "npm run test-nocover",


### PR DESCRIPTION
- Merged #72: Revamped batch API.
- Fixed #62: Added checks for server current `http_version_api` support.
- Fixed #68: Updated delete endpoint methods to not send JSON body data anymore. 
- Merged #61: Added `KintoClient#fetchServerInfo`, `KintoClient#fetchServerCapabilities`, `KintoClient#fetchUser` and `KintoClient#fetchHTTPApiVersion`.
