### PR TITLE
Fixes #71: Allow posting bucket data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Sample result:
 
 #### Options
 
+- `patch`: Patches existing bucket data instead of replacing them (default: `false`)
 - `headers`: Custom headers object to send along the HTTP request
 - `safe`: Whether to override existing resource if it already exists (default: `false`)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Read the [API documentation](https://doc.esdoc.org/github.com/Kinto/kinto-client
      - [Listing buckets](#listing-buckets)
      - [Creating a new bucket](#creating-a-new-bucket)
      - [Selecting a bucket](#selecting-a-bucket)
+     - [Setting bucket data](#setting-bucket-data)
      - [Getting bucket permissions](#getting-bucket-permissions)
      - [Setting bucket permissions](#setting-bucket-permissions)
      - [Deleting a bucket](#deleting-a-bucket)
@@ -137,6 +138,7 @@ Sample result:
 
 #### Options
 
+- `data`: Arbitrary data to attach to the bucket
 - `headers`: Custom headers object to send along the HTTP request
 - `safe`: Whether to override existing resource if it already exists (default: `false`)
 
@@ -145,6 +147,35 @@ Sample result:
 ```js
 client.bucket("blog");
 ```
+
+### Setting bucket data
+
+```js
+client.bucket("blog").setData({foo: "bar"})
+  .then(result => ...);
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "last_modified": 1456182336242,
+    "id": "blog",
+    "foo": "bar"
+  },
+  "permissions": {
+    "write": [
+      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8"
+    ]
+  }
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `safe`: Whether to override existing resource if it already exists (default: `false`)
 
 ### Getting bucket permissions
 

--- a/src/base.js
+++ b/src/base.js
@@ -383,6 +383,7 @@ export default class KintoClientBase {
    *
    * @param  {String}   bucketName      The bucket name.
    * @param  {Object}   options         The options object.
+   * @param  {Boolean}  options.data    The bucket data option.
    * @param  {Boolean}  options.safe    The safe option.
    * @param  {Object}   options.headers The headers object option.
    * @return {Promise<Object, Error>}

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -89,6 +89,17 @@ export default class Bucket {
   }
 
   /**
+   * Set bucket data.
+   * @param {Object} metadata The bucket meta
+   * @param {Object} options  [description]
+   */
+  setData(data, options={}) {
+    const reqOptions = {...this._bucketOptions(options)};
+    const request = requests.updateBucket({...data, id: this.name}, reqOptions);
+    return this.client.execute(request);
+  }
+
+  /**
    * Retrieves the list of collections in the current bucket.
    *
    * @param  {Object} options         The options object.

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -90,8 +90,12 @@ export default class Bucket {
 
   /**
    * Set bucket data.
-   * @param {Object} metadata The bucket meta
-   * @param {Object} options  [description]
+   * @param  {Object}   data            The bucket data object.
+   * @param  {Object}   options         The options object.
+   * @param  {Object}   options.headers The headers object option.
+   * @param  {Boolean}  options.safe    The safe option.
+   * @param  {Boolean}  options.patch   The patch option.
+   * @return {Promise<Object, Error>}
    */
   setData(data, options={}) {
     const reqOptions = {...this._bucketOptions(options)};

--- a/src/requests.js
+++ b/src/requests.js
@@ -29,13 +29,16 @@ export function createBucket(bucketName, options = {}) {
   }
   // Note that we simply ignore any "bucket" option passed here, as the one
   // we're interested in is the one provided as a required argument.
-  const { headers, permissions, safe } = {...requestDefaults, ...options};
+  const { data={}, headers, permissions, safe } = {
+    ...requestDefaults,
+    ...options,
+  };
   return {
     method: "PUT",
     path: endpoint("bucket", bucketName),
     headers: {...headers, ...safeHeader(safe)},
     body: {
-      // XXX We can't pass the data option just yet, see Kinto/kinto/issues/239
+      data,
       permissions
     }
   };

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -568,6 +568,16 @@ describe("KintoClient", () => {
       });
     });
 
+    it("should accept a data option", () => {
+      api.createBucket("foo", {data: {a: 1}});
+
+      sinon.assert.calledWithMatch(requests.createBucket, "foo", {
+        data: {a: 1},
+        headers: {},
+        safe: false,
+      });
+    });
+
     it("should accept a safe option", () => {
       api.createBucket("foo", {safe: true});
 

--- a/test/bucket_test.js
+++ b/test/bucket_test.js
@@ -78,6 +78,14 @@ describe("Bucket", () => {
       }, {headers: {}});
     });
 
+    it("should handle the patch option", () => {
+      getBlogBucket().setData({a: 1}, {patch: true});
+
+      sinon.assert.calledWithMatch(requests.updateBucket, {id: "blog", a: 1}, {
+        patch: true,
+      });
+    });
+
     it("should handle the safe option", () => {
       getBlogBucket().setData({a: 1}, {safe: true, last_modified: 42});
 

--- a/test/bucket_test.js
+++ b/test/bucket_test.js
@@ -63,6 +63,41 @@ describe("Bucket", () => {
     });
   });
 
+  describe("#setData()", () => {
+    beforeEach(() => {
+      sandbox.stub(requests, "updateBucket");
+      sandbox.stub(client, "execute").returns(Promise.resolve({data: 1}));
+    });
+
+    it("should set the bucket data", () => {
+      getBlogBucket().setData({a: 1});
+
+      sinon.assert.calledWithMatch(requests.updateBucket, {
+        id: "blog",
+        a: 1
+      }, {headers: {}});
+    });
+
+    it("should handle the safe option", () => {
+      getBlogBucket().setData({a: 1}, {safe: true, last_modified: 42});
+
+      sinon.assert.calledWithMatch(requests.updateBucket, {
+        id: "blog",
+        a: 1,
+      }, {
+        headers: {},
+        safe: true,
+        last_modified: 42,
+      });
+    });
+
+    it("should resolve with json result", () => {
+      return getBlogBucket().setData({a: 1})
+        .should.become({data: 1});
+    });
+  });
+
+
   /** @test {Bucket#collection} */
   describe("#collection()", () => {
     it("should return a Collection instance", () => {

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -135,6 +135,14 @@ describe("Integration tests", function() {
                         .to.have.property("write").to.be.a("array");
         });
 
+        describe("data option", () => {
+          it("should create bucket data", () => {
+            return api.createBucket("foo", {data: {a: 1}})
+              .should.eventually.have.property("data")
+                             .to.have.property("a").eql(1);
+          });
+        });
+
         describe("Safe option", () => {
           it("should not override existing bucket", () => {
             return api.createBucket("foo", {safe: true})
@@ -460,6 +468,14 @@ describe("Integration tests", function() {
         it("should have permissions exposed", () => {
           expect(result).to.have.property("permissions")
             .to.have.property("write").to.have.length.of(1);
+        });
+      });
+
+      describe(".setData()", () => {
+        it("should post data to the bucket", () => {
+          return bucket.setData({a: 1})
+            .then(({data}) => data)
+            .should.eventually.have.property("a").eql(1);
         });
       });
 

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -477,6 +477,15 @@ describe("Integration tests", function() {
             .then(({data}) => data)
             .should.eventually.have.property("a").eql(1);
         });
+
+        it("should patch existing data for the bucket", () => {
+          return bucket.setData({a: 1})
+            .then(() => bucket.setData({b: 2}, {patch: true}))
+            .then(({data}) => {
+              expect(data.a).eql(1);
+              expect(data.b).eql(2);
+            });
+        });
       });
 
       describe(".listCollections()", () => {

--- a/test/requests_test.js
+++ b/test/requests_test.js
@@ -14,6 +14,7 @@ describe("requests module", () => {
     it("should return a bucket creation request", () => {
       expect(requests.createBucket("foo")).eql({
         body: {
+          data: {},
           permissions: {}
         },
         headers: {},


### PR DESCRIPTION
Refs #71.

Note that this introduces yet another convention with `setData` while we already have `getAttributes`, `setMetadata` and friends. I'm panning to work on homogeneizing all this mess in a followup PR, where `getData` and `setData` will be the common convention (refs #83).

- [x] Allow posting bucket data upon creation in `createBucket`
- [x] Allow updating bucket data (`setData`)
- [x] Update docs

r=? @Natim @leplatrem