### PR TITLE
Rename methods for consistency (fixes #83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ const kinto = new KintoClient("https://my.server.tld/v1", {
 });
 ```
 
-
 ## Server information
 
 A Kinto server exposes some of its internal settings, information about authenticated user, the HTTP API version and the API capabilities (e.g. plugins).
@@ -176,6 +175,7 @@ Sample result:
 - `fetchServerCapabilities([options])`: API capabilities
 - `fetchUser()`: authenticated user information
 - `fetchHTTPApiVersion([options])`: HTTP API version
+
 
 ## Buckets
 
@@ -241,6 +241,28 @@ Sample result:
 ```js
 client.bucket("blog");
 ```
+
+### Getting bucket data
+
+```js
+client.bucket("blog").getData()
+  .then(result => ...);
+```
+
+Sample result:
+
+```js
+{
+  "last_modified": 1456182336242,
+  "id": "blog",
+  "foo": "bar"
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+
 
 ### Setting bucket data
 
@@ -478,6 +500,82 @@ client.bucket("blog").collection("posts")
   .then(result => ...);
 ```
 
+### Getting collection data
+
+```js
+client.bucket("blog").collection("posts").getData()
+  .then(result => ...);
+```
+
+Sample result:
+
+```js
+{
+  "last_modified": 1456183561206,
+  "id": "posts",
+  "preferedAuthor": "@chucknorris"
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+
+### Setting collection data
+
+```js
+client.bucket("blog").collection("posts")
+  .setData({preferedAuthor: "@chucknorris"})
+  .then(result => ...);
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "last_modified": 1456183561206,
+    "id": "posts",
+    "preferedAuthor": "@chucknorris"
+  },
+  "permissions": {
+    "write": [
+      "github:bob",
+      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8",
+      "github:john"
+    ]
+  }
+}
+```
+
+#### Options
+
+- `patch`: Patches the existing data instead of replacing them (default: `false`)
+- `headers`: Custom headers object to send along the HTTP request;
+- `safe`: If `last_modified` is provided, ensures the resource hasn't been modified since that timestamp. Otherwise ensures no existing resource with the provided id will be overriden (default: `false`);
+- `last_modified`: The last timestamp we know the resource has been updated on the server.
+
+### Getting collection permissions
+
+```js
+client.bucket("blog").collection("posts").getPermissions()
+  .then(result => ...);
+```
+
+Sample result:
+
+```js
+{
+  "write": [
+    "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8",
+  ]
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+
 ### Setting collection permissions
 
 ```js
@@ -519,60 +617,6 @@ Sample result:
 - This operation replaces any previously set permissions;
 - Owners will always keep their `write` permission bit, as per the Kinto protocol.
 
-### Setting collection data
-
-```js
-client.bucket("blog").collection("posts")
-  .setData({preferedAuthor: "@chucknorris"})
-  .then(result => ...);
-```
-
-Sample result:
-
-```js
-{
-  "data": {
-    "last_modified": 1456183561206,
-    "id": "posts",
-    "preferedAuthor": "@chucknorris"
-  },
-  "permissions": {
-    "write": [
-      "github:bob",
-      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8",
-      "github:john"
-    ]
-  }
-}
-```
-
-#### Options
-
-- `patch`: Patches the existing data instead of replacing them (default: `false`)
-- `headers`: Custom headers object to send along the HTTP request;
-- `safe`: If `last_modified` is provided, ensures the resource hasn't been modified since that timestamp. Otherwise ensures no existing resource with the provided id will be overriden (default: `false`);
-- `last_modified`: The last timestamp we know the resource has been updated on the server.
-
-### Getting collection data
-
-```js
-client.bucket("blog").collection("posts").getData()
-  .then(result => ...);
-```
-
-Sample result:
-
-```js
-{
-  "last_modified": 1456183561206,
-  "id": "posts",
-  "preferedAuthor": "@chucknorris"
-}
-```
-
-#### Options
-
-- `headers`: Custom headers object to send along the HTTP request
 
 ### Creating a new record
 

--- a/README.md
+++ b/README.md
@@ -478,90 +478,6 @@ client.bucket("blog").collection("posts")
   .then(result => ...);
 ```
 
-### Setting the [JSON schema](http://json-schema.org/) for a collection
-
-```js
-const schema = {
-  type: "object",
-  required: ["title", "content"],
-  properties: {
-    title: {type: "string"},
-    content: {type: "string"}
-  }
-};
-
-client.bucket("blog").collection("posts").setSchema(schema)
-  .then(result => ...);
-```
-
-Sample result:
-
-```js
-{
-  "data": {
-    "last_modified": 1456183376428,
-    "id": "posts",
-    "schema": {
-      "required": [
-        "title",
-        "content"
-      ],
-      "type": "object",
-      "properties": {
-        "content": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        }
-      }
-    }
-  },
-  "permissions": {
-    "write": [
-      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8"
-    ]
-  }
-}
-```
-
-#### Options
-
-- `headers`: Custom headers object to send along the HTTP request;
-- `safe`: If `last_modified` is provided, ensures the resource hasn't been modified since that timestamp. Otherwise ensures no existing resource with the provided id will be overriden (default: `false`);
-- `last_modified`: The last timestamp we know the resource has been updated on the server.
-
-### Retrieving the collection schema
-
-```js
-client.bucket("blog").collection("posts").getSchema()
-  .then(result => ...);
-```
-
-Sample result:
-
-```js
-{
-  "required": [
-    "title",
-    "content"
-  ],
-  "type": "object",
-  "properties": {
-    "content": {
-      "type": "string"
-    },
-    "title": {
-      "type": "string"
-    }
-  }
-}
-```
-
-#### Options
-
-- `headers`: Custom headers object to send along the HTTP request;
-
 ### Setting collection permissions
 
 ```js
@@ -603,11 +519,11 @@ Sample result:
 - This operation replaces any previously set permissions;
 - Owners will always keep their `write` permission bit, as per the Kinto protocol.
 
-### Setting collection metadata
+### Setting collection data
 
 ```js
 client.bucket("blog").collection("posts")
-  .setMetadata({preferedAuthor: "@chucknorris"})
+  .setData({preferedAuthor: "@chucknorris"})
   .then(result => ...);
 ```
 
@@ -637,10 +553,10 @@ Sample result:
 - `safe`: If `last_modified` is provided, ensures the resource hasn't been modified since that timestamp. Otherwise ensures no existing resource with the provided id will be overriden (default: `false`);
 - `last_modified`: The last timestamp we know the resource has been updated on the server.
 
-### Getting collection metadata
+### Getting collection data
 
 ```js
-client.bucket("blog").collection("posts").getMetadata()
+client.bucket("blog").collection("posts").getData()
   .then(result => ...);
 ```
 

--- a/src/base.js
+++ b/src/base.js
@@ -267,7 +267,7 @@ export default class KintoClientBase {
    * @param  {Object} options  The options object.
    * @return {Promise<Object, Error>}
    */
-  _batchRequests(requests, options = {}) {
+  _batchRequests(requests, options={}) {
     const headers = {...this.defaultReqOptions.headers, ...options.headers};
     if (!requests.length) {
       return Promise.resolve([]);

--- a/src/base.js
+++ b/src/base.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { partition, pMap, omit, support, nobatch } from "./utils";
+import { partition, pMap, omit, support, nobatch, toDataBody } from "./utils";
 import HTTP from "./http";
 import endpoint from "./endpoint";
 import * as requests from "./requests";
@@ -408,9 +408,8 @@ export default class KintoClientBase {
    * @return {Promise<Object, Error>}
    */
   deleteBucket(bucket, options={}) {
-    const _bucket = typeof bucket === "object" ? bucket : {id: bucket};
     const reqOptions = this._getRequestOptions(options);
-    return this.execute(requests.deleteBucket(_bucket, reqOptions));
+    return this.execute(requests.deleteBucket(toDataBody(bucket), reqOptions));
   }
 
   /**

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -126,7 +126,7 @@ export default class Bucket {
    * @param  {Boolean} options.safe        The safe option.
    * @param  {Object}  options.headers     The headers object option.
    * @param  {Object}  options.permissions The permissions object.
-   * @param  {Object}  options.data        The metadadata object.
+   * @param  {Object}  options.data        The data object.
    * @param  {Object}  options.schema      The JSONSchema object.
    * @return {Promise<Object, Error>}
    */

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -127,7 +127,6 @@ export default class Bucket {
    * @param  {Object}  options.headers     The headers object option.
    * @param  {Object}  options.permissions The permissions object.
    * @param  {Object}  options.data        The data object.
-   * @param  {Object}  options.schema      The JSONSchema object.
    * @return {Promise<Object, Error>}
    */
   createCollection(id, options={}) {

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -69,23 +69,24 @@ export default class Bucket {
    * @param  {Boolean}  options.safe  The safe option.
    * @return {Collection}
    */
-  collection(name, options) {
+  collection(name, options={}) {
     return new Collection(this.client, this, name, this._bucketOptions(options));
   }
 
 
   /**
-   * Retrieves bucket properties.
+   * Retrieves bucket data.
    *
    * @param  {Object} options         The options object.
    * @param  {Object} options.headers The headers object option.
    * @return {Promise<Object, Error>}
    */
-  getAttributes(options={}) {
+  getData(options={}) {
     return this.client.execute({
       path: endpoint("bucket", this.name),
       headers: {...this.options.headers, ...options.headers}
-    });
+    })
+    .then((res) => res.data);
   }
 
   /**
@@ -129,7 +130,7 @@ export default class Bucket {
    * @param  {Object}  options.schema      The JSONSchema object.
    * @return {Promise<Object, Error>}
    */
-  createCollection(id, options) {
+  createCollection(id, options={}) {
     const reqOptions = this._bucketOptions(options);
     const request = requests.createCollection(id, reqOptions);
     return this.client.execute(request);
@@ -144,7 +145,7 @@ export default class Bucket {
    * @param  {Boolean}   options.safe    The safe option.
    * @return {Promise<Object, Error>}
    */
-  deleteCollection(collection, options) {
+  deleteCollection(collection, options={}) {
     const reqOptions = this._bucketOptions(options);
     const request = requests.deleteCollection(toDataBody(collection), reqOptions);
     return this.client.execute(request);
@@ -157,9 +158,12 @@ export default class Bucket {
    * @param  {Object} options.headers The headers object option.
    * @return {Promise<Object, Error>}
    */
-  getPermissions(options) {
-    return this.getAttributes(this._bucketOptions(options))
-      .then(res => res.permissions);
+  getPermissions(options={}) {
+    return this.client.execute({
+      path: endpoint("bucket", this.name),
+      headers: {...this.options.headers, ...options.headers}
+    })
+    .then((res) => res.permissions);
   }
 
   /**
@@ -190,7 +194,7 @@ export default class Bucket {
    * @param  {Boolean}  options.aggregate  Produces a grouped result object.
    * @return {Promise<Object, Error>}
    */
-  batch(fn, options) {
+  batch(fn, options={}) {
     return this.client.batch(fn, this._bucketOptions(options));
   }
 }

--- a/src/collection.js
+++ b/src/collection.js
@@ -99,8 +99,6 @@ export default class Collection {
    * @return {Promise<Object, Error>}
    */
   setData(data, options={}) {
-    // Note: patching allows preventing overridding the schema, which lives
-    // within the "data" namespace.
     return this.client.execute(requests.updateCollection({
       ...data,
       id: this.name,

--- a/src/requests.js
+++ b/src/requests.js
@@ -123,7 +123,6 @@ export function createCollection(id, options={}) {
     ...requestDefaults,
     ...options
   };
-  // XXX checks that provided data can't override schema when provided
   const path = id ? endpoint("collection", bucket, id) :
                     endpoint("collections", bucket);
   return {

--- a/src/requests.js
+++ b/src/requests.js
@@ -23,7 +23,7 @@ function safeHeader(safe, last_modified) {
 /**
  * @private
  */
-export function createBucket(bucketName, options = {}) {
+export function createBucket(bucketName, options={}) {
   if (!bucketName) {
     throw new Error("A bucket name is required.");
   }
@@ -47,7 +47,7 @@ export function createBucket(bucketName, options = {}) {
 /**
  * @private
  */
-export function updateBucket(bucket, options = {}) {
+export function updateBucket(bucket, options={}) {
   if (typeof bucket !== "object") {
     throw new Error("A bucket object is required.");
   }
@@ -75,7 +75,7 @@ export function updateBucket(bucket, options = {}) {
 /**
  * @private
  */
-export function deleteBucket(bucket, options = {}) {
+export function deleteBucket(bucket, options={}) {
   if (typeof bucket !== "object") {
     throw new Error("A bucket object is required.");
   }
@@ -100,7 +100,7 @@ export function deleteBucket(bucket, options = {}) {
 /**
  * @private
  */
-export function deleteBuckets(options = {}) {
+export function deleteBuckets(options={}) {
   const { headers, safe, last_modified} = {
     ...requestDefaults,
     ...options
@@ -118,7 +118,7 @@ export function deleteBuckets(options = {}) {
 /**
  * @private
  */
-export function createCollection(id, options = {}) {
+export function createCollection(id, options={}) {
   const { bucket, headers, permissions, data, safe } = {
     ...requestDefaults,
     ...options
@@ -137,7 +137,7 @@ export function createCollection(id, options = {}) {
 /**
  * @private
  */
-export function updateCollection(collection, options = {}) {
+export function updateCollection(collection, options={}) {
   if (typeof collection !== "object") {
     throw new Error("A collection object is required.");
   }
@@ -148,16 +148,10 @@ export function updateCollection(collection, options = {}) {
     bucket,
     headers,
     permissions,
-    schema,
-    metadata,
     safe,
     patch,
     last_modified
   } = {...requestDefaults, ...options};
-  const collectionData = {...metadata, ...collection};
-  if (options.schema) {
-    collectionData.schema = schema;
-  }
   return {
     method: patch ? "PATCH" : "PUT",
     path: endpoint("collection", bucket, collection.id),
@@ -166,7 +160,7 @@ export function updateCollection(collection, options = {}) {
       ...safeHeader(safe, last_modified || collection.last_modified)
     },
     body: {
-      data: collectionData,
+      data: collection,
       permissions
     }
   };
@@ -175,7 +169,7 @@ export function updateCollection(collection, options = {}) {
 /**
  * @private
  */
-export function deleteCollection(collection, options = {}) {
+export function deleteCollection(collection, options={}) {
   if (typeof collection !== "object") {
     throw new Error("A collection object is required.");
   }
@@ -200,7 +194,7 @@ export function deleteCollection(collection, options = {}) {
 /**
  * @private
  */
-export function createRecord(collName, record, options = {}) {
+export function createRecord(collName, record, options={}) {
   if (!collName) {
     throw new Error("A collection name is required.");
   }
@@ -225,7 +219,7 @@ export function createRecord(collName, record, options = {}) {
 /**
  * @private
  */
-export function updateRecord(collName, record, options = {}) {
+export function updateRecord(collName, record, options={}) {
   if (!collName) {
     throw new Error("A collection name is required.");
   }
@@ -253,7 +247,7 @@ export function updateRecord(collName, record, options = {}) {
 /**
  * @private
  */
-export function deleteRecord(collName, record, options = {}) {
+export function deleteRecord(collName, record, options={}) {
   if (!collName) {
     throw new Error("A collection name is required.");
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,15 +61,15 @@ export function omit(obj, ...keys) {
  * Always returns a resource data object from the provided argument.
  *
  * @private
- * @param  {Object|String} value
+ * @param  {Object|String} resource
  * @return {Object}
  */
-export function toDataBody(value) {
-  if (typeof value === "object") {
-    return value;
+export function toDataBody(resource) {
+  if (typeof resource === "object") {
+    return resource;
   }
-  if (typeof value === "string") {
-    return {id: value};
+  if (typeof resource === "string") {
+    return {id: resource};
   }
   throw new Error("Invalid argument.");
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -71,7 +71,7 @@ export function toDataBody(value) {
   if (typeof value === "string") {
     return {id: value};
   }
-  throw new Error("Invalid collection argument.");
+  throw new Error("Invalid argument.");
 }
 
 /**

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -34,12 +34,12 @@ describe("Collection", () => {
     return new Bucket(client, "blog").collection("posts", options);
   }
 
-  /** @test {Collection#getAttributes} */
-  describe("#getAttributes()", () => {
+  /** @test {Collection#getData} */
+  describe("#getData()", () => {
     it("should execute expected request", () => {
       sandbox.stub(client, "execute").returns(Promise.resolve());
 
-      getBlogPostsCollection().getAttributes();
+      getBlogPostsCollection().getData();
 
       sinon.assert.calledWithMatch(client.execute, {
         path: "/buckets/blog/collections/posts",
@@ -47,25 +47,25 @@ describe("Collection", () => {
     });
 
     it("should resolve with response data", () => {
-      const data = {data: true};
-      sandbox.stub(client, "execute").returns(Promise.resolve(data));
+      const response = {data: {foo: "bar"}};
+      sandbox.stub(client, "execute").returns(Promise.resolve(response));
 
-      return getBlogPostsCollection().getAttributes()
-        .should.become(data);
+      return getBlogPostsCollection().getData()
+        .should.become({foo: "bar"});
     });
   });
 
   /** @test {Collection#getPermissions} */
   describe("#getPermissions()", () => {
     beforeEach(() => {
-      sandbox.stub(coll, "getAttributes").returns(Promise.resolve({
-        permissions: "fakeperms"
+      sandbox.stub(client, "execute").returns(Promise.resolve({
+        data: {}, permissions: {"write": ["fakeperms"]}
       }));
     });
 
     it("should retrieve permissions", () => {
       return coll.getPermissions()
-        .should.become("fakeperms");
+        .should.become({"write": ["fakeperms"]});
     });
   });
 
@@ -108,110 +108,53 @@ describe("Collection", () => {
     });
   });
 
-  /** @test {Collection#getSchema} */
-  describe("#getSchema()", () => {
-    const schema = {title: "schema"};
-
+  /** @test {Collection#getData} */
+  describe("#getData()", () => {
     beforeEach(() => {
-      sandbox.stub(coll, "getAttributes").returns(Promise.resolve({
-        data: {schema}
-      }));
+      sandbox.stub(client, "execute").returns(Promise.resolve({data: {a: 1}}));
     });
 
-    it("should retrieve the collection schema", () => {
-      return coll.getSchema()
-        .should.become(schema);
-    });
-  });
-
-  /** @test {Collection#setSchema} */
-  describe("#setSchema()", () => {
-    const schema = {title: "schema"};
-
-    beforeEach(() => {
-      sandbox.stub(requests, "updateCollection");
-      sandbox.stub(client, "execute").returns(Promise.resolve({data: 1}));
-    });
-
-    it("should set the collection schema", () => {
-      coll.setSchema(schema);
-
-      sinon.assert.calledWithMatch(requests.updateCollection, {id: "posts"}, {
-        bucket: "blog",
-        schema,
-        headers: {Foo: "Bar", Baz: "Qux"},
-      });
-    });
-
-    it("should handle the safe option", () => {
-      coll.setSchema(schema, {safe: true, last_modified: 42});
-
-      sinon.assert.calledWithMatch(requests.updateCollection, {
-        id: "posts",
-      }, {
-        bucket: "blog",
-        headers: {Foo: "Bar", Baz: "Qux"},
-        schema,
-        safe: true,
-        last_modified: 42
-      });
-    });
-
-    it("should resolve with json result", () => {
-      return coll.setSchema(schema)
-        .should.become({data: 1});
-    });
-  });
-
-  /** @test {Collection#getMetadata} */
-  describe("#getMetadata()", () => {
-    beforeEach(() => {
-      sandbox.stub(coll, "getAttributes").returns(Promise.resolve({
-        data: {a: 1}
-      }));
-    });
-
-    it("should retrieve metadata", () => {
-      return coll.getMetadata()
+    it("should retrieve data", () => {
+      return coll.getData()
         .should.become({a: 1});
     });
   });
 
-  describe("#setMetadata()", () => {
+  describe("#setData()", () => {
     beforeEach(() => {
       sandbox.stub(requests, "updateCollection");
-      sandbox.stub(client, "execute").returns(Promise.resolve({data: 1}));
+      sandbox.stub(client, "execute").returns(Promise.resolve({data: {foo: "bar"}}));
     });
 
-    it("should set the metadata", () => {
-      coll.setMetadata({a: 1});
+    it("should set the data", () => {
+      coll.setData({a: 1});
 
-      sinon.assert.calledWithMatch(requests.updateCollection, {id: "posts"}, {
+      sinon.assert.calledWithMatch(requests.updateCollection,{
+        id: "posts",
+        a: 1,
+      }, {
         bucket: "blog",
-        patch: true,
         headers: {Foo: "Bar", Baz: "Qux"},
-        metadata: {a: 1}
       });
     });
 
     it("should handle the safe option", () => {
-      coll.setMetadata({a: 1}, {safe: true, last_modified: 42});
+      coll.setData({a: 1}, {safe: true, last_modified: 42});
 
       sinon.assert.calledWithMatch(requests.updateCollection, {
         id: "posts",
+        a: 1
       }, {
         bucket: "blog",
         headers: {Foo: "Bar", Baz: "Qux"},
-        patch: true,
         safe: true,
         last_modified: 42,
-        metadata: {a: 1}
       });
     });
 
     it("should resolve with json result", () => {
-      return coll.setMetadata({a: 1})
-        .should.become({data: 1});
+      return coll.setData({a: 1})
+        .should.become({data: {foo: "bar"}});
     });
   });
 

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -450,24 +450,19 @@ describe("Integration tests", function() {
           }));
       });
 
-      describe(".getAttributes()", () => {
+      describe(".getData()", () => {
         let result;
 
         beforeEach(() => {
-          return bucket.getAttributes().then(res => result = res);
+          return bucket.getData().then(res => result = res);
         });
 
         it("should retrieve the bucket identifier", () => {
-          expect(result.data).to.have.property("id").eql("custom");
+          expect(result).to.have.property("id").eql("custom");
         });
 
         it("should retrieve bucket last_modified value", () => {
-          expect(result.data).to.have.property("last_modified").to.be.gt(1);
-        });
-
-        it("should have permissions exposed", () => {
-          expect(result).to.have.property("permissions")
-            .to.have.property("write").to.have.length.of(1);
+          expect(result).to.have.property("last_modified").to.be.gt(1);
         });
       });
 
@@ -664,67 +659,24 @@ describe("Integration tests", function() {
             });
           });
 
-          describe(".getSchema()", () => {
-            const schema = {
-              type: "object",
-              properties: {
-                title: {type: "string"}
-              }
-            };
-
-            beforeEach(() => {
-              return coll.setSchema(schema);
-            });
-
-            it("should retrieve collection schema", () => {
-              return coll.getSchema()
-                .should.become(schema);
+          describe(".getData()", () => {
+            it("should retrieve collection data", () => {
+              return coll.setData({signed: true})
+                .then(_ => coll.getData())
+                .should.eventually.have.property("signed").eql(true);
             });
           });
 
-          describe(".setSchema()", () => {
-            const schema = {
-              type: "object",
-              properties: {
-                title: {type: "string"}
-              }
-            };
-
-            it("should set the collection schema", () => {
-              return coll.setSchema(schema)
-                .then(_ => coll.getSchema())
-                .should.become(schema);
+          describe(".setData()", () => {
+            it("should set collection data", () => {
+              return coll.setData({signed: true})
+                .then(_ => coll.getData())
+                .should.eventually.have.property("signed").eql(true);
             });
 
             describe("Safe option", () => {
               it("should perform concurrency checks", () => {
-                return coll.setSchema(schema, {
-                  safe: true,
-                  last_modified: 1
-                })
-                  .should.be.rejectedWith(Error, /412 Precondition Failed/);
-              });
-            });
-          });
-
-          describe(".getMetadata()", () => {
-            it("should retrieve collection metadata", () => {
-              return coll.setMetadata({isMeta: true})
-                .then(_ => coll.getMetadata())
-                .should.eventually.have.property("isMeta").eql(true);
-            });
-          });
-
-          describe(".setMetadata()", () => {
-            it("should set collection metadata", () => {
-              return coll.setMetadata({isMeta: true})
-                .then(_ => coll.getMetadata())
-                .should.eventually.have.property("isMeta").eql(true);
-            });
-
-            describe("Safe option", () => {
-              it("should perform concurrency checks", () => {
-                return coll.setMetadata({isMeta: true}, {
+                return coll.setData({signed: true}, {
                   safe: true,
                   last_modified: 1
                 })

--- a/test/requests_test.js
+++ b/test/requests_test.js
@@ -154,18 +154,16 @@ describe("requests module", () => {
   });
 
   describe("updateCollection()", () => {
-    const schema = {title: "foo schema"};
-
     it("should require a collection id", () => {
       expect(() => requests.updateCollection())
         .to.Throw(Error, /required/);
     });
 
     it("should return a collection update request", () => {
-      expect(requests.updateCollection({id: "foo"}, {schema})).eql({
+      expect(requests.updateCollection({id: "foo", age: 42})).eql({
         body: {
           permissions: {},
-          data: {id: "foo", schema}
+          data: {id: "foo", age: 42}
         },
         headers: {},
         method: "PUT",
@@ -190,26 +188,13 @@ describe("requests module", () => {
         .to.have.property("permissions").eql(permissions);
     });
 
-    it("should accept a schema option", () => {
-      expect(requests.updateCollection({id: "foo"}, {schema}))
-        .to.have.property("body")
-        .to.have.property("data")
-        .to.have.property("schema").eql(schema);
-    });
-
     it("should accept a patch option", () => {
-      expect(requests.updateCollection({id: "foo"}, {schema, patch: true}))
+      expect(requests.updateCollection({id: "foo"}, {patch: true}))
         .to.have.property("method").eql("PATCH");
     });
 
-    it("should handle metadata from resource body", () => {
+    it("should handle data from resource body", () => {
       expect(requests.updateCollection({id: "foo", a: 1}))
-        .to.have.property("body")
-        .to.have.property("data").eql({id: "foo", a: 1});
-    });
-
-    it("should handle metadata from dedicated option", () => {
-      expect(requests.updateCollection({id: "foo"}, {metadata: {a: 1}}))
         .to.have.property("body")
         .to.have.property("data").eql({id: "foo", a: 1});
     });
@@ -294,7 +279,7 @@ describe("requests module", () => {
         .to.have.property("permissions").eql(permissions);
     });
 
-    it("should handle metadata", () => {
+    it("should handle data", () => {
       expect(requests.updateBucket({id: "foo", a: 1}))
         .to.have.property("body")
         .to.have.property("data").eql({id: "foo", a: 1});


### PR DESCRIPTION
@n1k0 please review thoroughly :)

* [x] `bucket.getData()` now returns `data`
* [x] rename attributes/metadata to data
* [x] remove get/setSchema
* [x] add missing documentation for get/setdata
* [x] Describe breaking changes

```
**Breaking changes**

- `client.bucket(...).getData()` now returns the `data` object instead of both data and permissions
- `Collection#setSchema()` and `Collection#getSchema()` were dropped. 
- `Collection#getAttributes()` was splited into `Collection#getData()` and `Collection#getPermissions()`
- `Collection#getMetadata()` is now `Collection#getData()`
- `Collection#setMetadata()` is now `Collection#setData()`
```